### PR TITLE
Add a note about the purpose of this API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # API
 
+While working on this API, you should consider how the end user would
+interact with the endpoints. Even though it is called internal, it may be
+published in the future.
+
 ## Setup
 
 ```


### PR DESCRIPTION
The fact that the API is called `internal` can be confusing and there should be a note about it in the README file.
