### PR TITLE
Add Build badge entity

### DIFF
--- a/entities/build_badge.yml.erb
+++ b/entities/build_badge.yml.erb
@@ -1,6 +1,6 @@
 ---
 "$schema": http://json-schema.org/draft-04/hyper-schema
-title: Build badge
+title: BuildBadge
 description: A build badge is a set of embeddable code options for displaying build status of a Semaphore project
 stability: prototype
 strictProperties: true


### PR DESCRIPTION
This PR introduces a `build badge` entity which will be used in the new build page to render Build badge CTA.
