### PR TITLE
type: string or nil

### DIFF
--- a/raml/api.raml
+++ b/raml/api.raml
@@ -64,8 +64,12 @@ types:
         enum: [read, write, admin]
       description?: string
   Team:
-    type: TeamPost
+    type: object
     properties:
+      name: string
+      permission:
+        enum: [read, write, admin]
+      description: string?
       id: integer
       url: string
       updated_at:


### PR DESCRIPTION
string? === string | nil

There is issue with `raml2html` tool.
It does not handle well polymorphic types: it shows no properties for them, which makes documentation useless.

[I deployed manually this commit]
look at http://api-docs.semaphoreci.com/#teams__team_id__get
go to response tab