### PR TITLE
Test syntax 

### DIFF
--- a/raml/api.raml
+++ b/raml/api.raml
@@ -180,6 +180,7 @@ traits:
 /foo:
   description: Auto generated tests example
   get:
+    is: [withNotFoundError]
     responses:
       404:
         (testAnnotation.tests):
@@ -187,25 +188,40 @@ traits:
               body: []
           - request:
               header:
-                - key: Authentication
+                - name: Authentication
                   value: Token <replaced during test generation>
-                - key: X-foo
+                - name: X-foo
                   value: bar
             response:
               header:
-                - key: X-foo
+                - name: X-foo
                   value: ppp
-                - key: X-bar
+                - name: X-bar
                   value: baz
               body:
-                - key: message
+                - name: message
                   type: string
                   value: pera
-                - key: foo
+                - name: foo
                   type: date
-        body:
-          application/json:
-            type: Error
+  /{foo_id}:
+    get:
+      is: [withResponseItem: {item : User}]
+      responses:
+        200:
+          (testAnnotation.tests):
+          - request:
+              urlArgs:
+              - name: org_username
+                value: <valid_foo_id>
+            response:
+              body:
+              - name: username
+                type: string
+              - name: realname
+                type: string
+              - name: email
+                type: string
 
 /users:
   description: |
@@ -230,11 +246,52 @@ traits:
   get:
     description: Get list of all organizations available to the user
     is: [withResponseItems: {item : Org}]
+    responses:
+      200:
+        (testAnnotation.tests):
+          - response:
+              body:
+                - name: id
+                  type: integer
+                - name: name
+                  type: string
+                - name: username
+                  type: string
+                - name: description
+                  type: string | nil
   /{org_username}:
     get:
       description: "Get organization details\n\n
       Precondition:\n - organization with {org_username} exists\n\n\n"
       is: [withResponseItem: {item : Org}, withNotFoundError]
+      responses:
+        200:
+          (testAnnotation.tests):
+          - request:
+              urlArgs:
+              - name: org_username
+                value: <valid_org_username>
+            response:
+              body:
+              - name: id
+                type: integer
+              - name: name
+                type: string
+                value: <valid_org_username>
+              - name: username
+                type: string
+              - name: description
+                type: string | nil
+        404:
+          (testAnnotation.tests):
+          - request:
+              urlArgs:
+              - name: org_username
+                value: nonexiting_username
+            response:
+              body:
+              - name: message
+                type: string
     /teams:
       get:
         description: "List teams that belong to {org_username} organisation\n\n

--- a/raml/libraries/tests-annotation.raml
+++ b/raml/libraries/tests-annotation.raml
@@ -1,8 +1,11 @@
 #%RAML 1.0 Library
-usage: Used to specify basic API tests 
+usage: Used to specify basic API tests
 
 annotationTypes:
   tests:
+    description: |
+      Note: Same description is used for both `object` and `array`.
+      If returned type is `array` all elements must conform to spec.
     allowedTargets: Response
     type: Test[]
 
@@ -15,8 +18,14 @@ types:
   TestRequest:
     additionalProperties: false
     properties:
+      urlArgs?: TestUrlArgs[]
       header?: TestHeaderItems[]
       body?: TestRequestBodyItems[]
+  TestUrlArgs:
+    additionalProperties: false
+    properties:
+      name: string
+      value: string
   TestResponse:
     additionalProperties: false
     properties:
@@ -25,16 +34,16 @@ types:
   TestHeaderItems:
     additionalProperties: false
     properties:
-      key:
+      name:
       value:
   TestRequestBodyItems:
     additionalProperties: false
     properties:
-      key:
+      name:
       value: any
   TestResponseBodyItems:
     additionalProperties: false
     properties:
-      key:
+      name:
       type:
       value?: any


### PR DESCRIPTION
There are 2 tests defined both for resource `/foo`, method `get` and response code `404`.
First test has only response defined, no request body and no request headers.
Something like:
`curl https://localhost/foo`
In response it validates no headers and nothing from the body, expecting `404` only.

Second test has both request and response part.

Request like:
`curl https://localhost/foo -H "Authentication: Token <replaced during test generation>"  -H "X-Foo: bar" `
and expecting headers 
- `X-foo: ppp` and
- `X-bar: baz`

And json body like : `{"message": "pera", "foo": "2017-05-07"}`
Test will check:
1. existence of key `message`, that it is of type `string` and value `pera`
2. existence of key `foo` and that it is of type `date` (whatever that means).

There is also test for resource `/foo/{foo_id}`.
It shows how to setup url arguments in request:
`curl https://localhost/foo/{<replaced during test generation>}`