### PR TITLE
Fix missing node package in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,8 @@ RUN mkdir -p doc
 RUN npm install -g raml2html
 RUN npm install -g raml2html-markdown-theme
 RUN npm install -g raml2html-slate-theme
-RUN npm i raml2obj --save
+RUN npm install -g raml2obj
+
+ENV NODE_PATH=/usr/local/lib/node_modules
 
 CMD ./scripts/server

--- a/scripts/server
+++ b/scripts/server
@@ -1,6 +1,6 @@
 #/usr/bin/env bash
 
-mkdir doc
+mkdir -p doc
 
 bundle exec guard --no-interactions &
 


### PR DESCRIPTION
I didn't have a node_packages directory locally and the node packages
were not installed in docker.

After, installing the node package globally in docker and exporting the
path to it, everything worked great. :+1: