### PR TITLE
Prepare titles for publishing

### DIFF
--- a/raml/api.raml
+++ b/raml/api.raml
@@ -178,9 +178,8 @@ traits:
             type: Error
 
 /orgs:
-  description: Manage Semaphore organizations
   get:
-    description: Get list of all organizations available to the user
+    description: List your organizations
     is: [withResponseItems: {item : Org}]
     responses:
       200:
@@ -197,8 +196,7 @@ traits:
                   type: string | nil
   /{org_username}:
     get:
-      description: "Get organization details\n\n
-      Precondition:\n - organization with {org_username} exists\n\n\n"
+      description: Get an organization
       is: [withResponseItem: {item : Org}, withNotFoundError]
       responses:
         200:
@@ -230,479 +228,139 @@ traits:
                 type: string
     /teams:
       get:
-        description: "List teams that belong to {org_username} organisation\n\n
-        Precondition:\n - organization with {org_username} exists\n\n\n"
+        description: List teams in an organization
         is: [withResponseItems: {item : Team}]
       post:
-        description: "Create team within the {org_username} organization.\n\n
-        Precondition:\n - team with {name} in request body does not exist\n\n\n
-        Postcondition:\n - team with {name} in request body {org_username} exists
-        "
+        description: Create a team in an organization
         is: [withRequestItem: {item : TeamPost},
              withResponseItem: {item : Team},
              withNotFoundError,
              withPreconditionFailedError]
     /projects:
       get:
-        description: List projects that belong to {org_username} organisation
+        description: List projects in an organization
         is: [withResponseItems: {item : Project}]
-      post:
-        description: |
-          Create project within the {org_username} organization
-
-          Precondition:
-            - Requester is member of {admin} or {owner} team.
-
-          Postcondition:
-            - new project with {name} and new id exists.
-
-          *Note*: Projects with the same name can exist within an organization.
-                Projects are uniquely identified by id.
-        is: [withRequestItem: {item : ProjectPost},
-             withResponseItem: {item : Project},
-             withNotFoundError,
-             withPreconditionFailedError]
     /shared_configs:
       get:
-        description: |
-          List shared configurations that belong to {org_username} organisation
-
-          Preconditions:
-          - one of:
-            - Requester is member of team with at least `write` permission or
-            - Requester is owner
-
-          Postconditions
+        description: List shared configurations in an organization
         is: [withResponseItems: {item : SharedConfig}]
       post:
-        description: |
-          Create shared configuration within the {org_username} organization
-
-          Preconditions:
-          - {name} shared config does not exist in {org_username} organization
-          - one of:
-            - Requester is member of team with `admin` permission or
-            - Requester is owner
-
-          Postconditions:
-          - {name} shared config exists in {org_username} organization
+        description: Create shared configuration in an organization
         is: [withRequestItem: {item : SharedConfigPost},
             withResponseItem: {item : SharedConfig},
             withNotFoundError,
             withPreconditionFailedError]
 
 /teams/{team_id}:
-  description: Manage Semaphore teams
   get:
-    description: |
-      Get {team_id} team details
-
-      Precondition:
-      - {team_id} team exists
-      - one of:
-        - Requester is member of team with at least `write` permission or
-        - Requester is owner
+    description: Get a team
     is: [withResponseItem: {item : Team}, withNotFoundError]
   delete:
-    description: |
-      Delete team
-
-      Precondition:
-      - {team_id} team exists
-      - one of:
-        - Requester is member of team with `admin` permission or
-        - Requester is owner
-
-      Postcondition:
-      - {team_id} team does not exist
+    description: Delete a team
     is: [withNoBodyResponse, withNotFoundError]
   patch:
-    description: |
-      Update team.
-
-      Precondition:
-      - {team_id} team exists.
-      - one of:
-        - Requester is member of team with `admin` permission or
-        - Requester is owner
-
-      Postcondition:
-      - {team_id} team exists but with altered attributes.
+    description: Update a team
     is: [withRequestItem: {item : TeamPatch}, withResponseItem: {item : Team}, withNotFoundError]
-
   /shared_configs:
     get:
-      description: |
-        List all shared configurations added/belonging to {team_id} team
-
-        Preconditions:
-        - {team_id} team exists.
-        - one of:
-          - Requester is member of {team_id} team and the team has
-            at least `write` permission or
-          - Requester is owner
+      description: List shared configurations in a team
       is: [withResponseItems: {item : SharedConfig}, withNotFoundError]
     /{shared_config_id}:
-      description: Manage relations between {team_id} team and
-                    {shared_config_id} shared configuration
       post:
-        description: |
-          Add {shared_config_id} shared configuration to {team_id} team
-
-          Preconditions:
-          - {team_id} team exists
-          - {shared_config_id} shared configuration exists
-          - one of:
-            - Requester is member of {team_id} team and the team has
-              `admin` permission or
-            - Requester is owner
-
-          Postcondition:
-          - {shared_config_id} shared configuration is {team_id} team member
+        description: Add a shared configuration to a team
         is: [withNoBodyResponse, withNotFoundError]
       delete:
-        description: |
-          Remove {shared_config_id} shared configuration from {team_id} team
-
-          Precondition:
-          - {shared_config_id} shared configuration is {team_id} team member
-          - one of:
-            - Requester is member of {team_id} team and the team has
-              `admin` permission or
-            - Requester is owner
-
-          Postcondition:
-          - {shared_config_id} shared configuration is *not* {team_id} team member
-
-          *Note*: It is allowed to remove shared configuration from the team
-          even if there are projects to which that shared configuration is
-          still attached to, in the team?
+        description: Remove shared configuration from a team
         is: [withNoBodyResponse, withNotFoundError]
 
 /projects/{project_id}:
-  description: Manage Semaphore projects
-
   /shared_configs:
     get:
-      description: |
-        List all shared configurations attached to {project_id} project
-
-        Preconditions:
-        - {project_id} project exists
-        - one of:
-          - Requester and {project_id} project are members of the team with
-            at least `write` permission or
-          - Requester is owner
+      description: List shared configurations attached to a project
       is: [withResponseItems: {item : SharedConfig}, withNotFoundError]
     /{shared_config_id}:
       post:
-        description: |
-          Attach {shared_config_id} shared configuration to {project_id} project
-
-          Precondition:
-          - {project_id} project exists
-          - {shared_config_id} shared configuration exists
-          - {shared_config_id} shared configuration is not attached to {project_id} project
-          - one of:
-            - Requester, {project_id} project and {shared_config_id} shared configuration
-              all belong to the team with at least {write} permission or
-            - Requester is owner
-
-          Postconditions:
-          - {shared_config_id} shared configuration is attached to {project_id} project
+        description: Attach a shared configuration to a project
         is: [withResponseItem: {item : SharedConfig}, withNotFoundError]
       delete:
-        description: |
-          Dettach {shared_config_id} shared configuration from {project_id} project
-
-          Precondition:
-          - {shared_config_id} shared configuration is attached to {project_id} project
-          - no resoureces from {shared_config_id} shared configuration is connected to
-            {project_id} project
-          - one of:
-            - Requester, {project_id} project and {shared_config_id} shared configuration
-              all belong to the team with at least {write} permission or
-            - Requester is owner
-
-          Postconditions:
-          - {shared_config_id} shared configuration is *not*  attached to {project_id} project
+        description: Dettach a shared configuration from a project
         is: [withNoBodyResponse, withNotFoundError]
+
   /env_vars:
     get:
-      description: |
-        List all env variables connected to {project_id} project
-
-        Preconditions:
-        - {project_id} project exists
-        - Requester and {project_id} project belong to team with at least
-          {write} permisson
+      description: List environment variables connected to a project
       is: [withResponseItems: {item : EnvVar}, withNotFoundError]
     /{env_var_id}:
       post:
-        description: |
-          Connect {env_var_id} shared env var to {project_id} project
-
-          Precondition:
-          - {shared_env_var_id} shared env var belongs to shared configuration that is
-            attached to {project_id} project
-          - {shared_env_var_id} shared env var is not connected to {project_id} project
-          - one of:
-            - Requester and {project_id} project belong to the team
-              with {write} permission or
-            - Requester is owner
-
-          Postconditions:
-          - {shared_env_var_id} shared env var is connected to {project_id} project
+        description: Connect a shared environment variable to a project
         is: [withNoBodyResponse, withNotFoundError]
       delete:
-        description: |
-          Dissconnect {shared_env_var_id} shared env var from {project_id} project
-
-          Preconditions:
-          - {shared_env_var_id} shared env var is connected to {project_id} project
-          - one of:
-            - Requester and {project_id} project belong to the team
-              with {write} permission or
-            - Requester is owner
-
-          Postconditions:
-          - {shared_env_var_id} shared env var is *not* connected to {project_id} project
+        description: Dissconnect a shared environment variable from a project
         is: [withNoBodyResponse, withNotFoundError]
+
   /config_files:
     get:
-      description: |
-        List all config files connected to {project_id} project
-
-          Preconditions:
-          - {project_id} project exists
-          - Requester and {project_id} project belong to team with at least
-            {write} permisson
+      description: List config files connected to a project
       is: [withResponseItems: {item : ConfigFile}, withNotFoundError]
     /{config_file_id}:
       post:
-        description: |
-          Connect {shared_conf_file_id} shared conf file to {project_id} project
-
-          Preconditions:
-          - {shared_conf_file_id} shared conf file belongs to shared configuration that is
-            attached to {project_id} project
-          - {shared_conf_file_id} shared conf file is not connected to {project_id} project
-          - one of:
-            - Requester and {project_id} project belong to the team
-              with {write} permission or
-            - Requester is owner
-
-          Postconditions:
-          - {shared_conf_file_id} shared conf file is connected to {project_id} project
+        description: Connect a shared config file to a project
         is: [withNoBodyResponse, withNotFoundError]
       delete:
-        description: |
-          Dissconnect {shared_conf_file_id} shared conf file from {project_id} project
-
-          Preconditions:
-          - {shared_conf_file_id} shared conf file is connected to {project_id} project
-          - one of:
-            - Requester and {project_id} project belong to the team
-              with at least {write} permission or
-            - Requester is owner
-
-          Postconditions:
-          - {shared_conf_file_id} shared conf file is *not* connected to {project_id} project
+        description: Dissconnect a shared config file from a project
         is: [withNoBodyResponse, withNotFoundError]
 
 /shared_config:
-  description: Manage Semaphore shared configurations
   /{shared_config_id}:
     get:
-      description: |
-        Show {shared_config_id} shared config details
-
-        Preconditions:
-        - {shared_config_id} shared configuration exists
-        - one of:
-          - Requester and {shared_config_id} shared configuration belong to the team
-            with at least {write} permission or
-          - Requester is owner
+      description: Get a shared configuration
       is: [withResponseItem: {item : SharedConfig}, withNotFoundError]
     delete:
-      description: |
-        Delete {shared_config_id} shared config
-
-        Preconditions:
-        - {shared_config_id} shared configuration exists
-        - {shared_config_id} shared configuration is *not* attached to any project
-        - one of:
-          - Requester and {shared_config_id} shared configuration belong to the team
-            with {admin} permission or
-          - Requester is owner
-
-        Postconditions:
-        - {shared_config_id} shared configuration does *not* exist
+      description: Delete a shared configuration
       is: [withNoBodyResponse, withNotFoundError]
     patch:
-      description: |
-        Update {shared_config_id} shared configuration attributes
-
-        Preconditions:
-        - {shared_config_id} shared configuration exists
-        - one of:
-          - Requester and {shared_config_id} shared configuration belong to the team
-            with {admin} permission or
-          - Requester is owner
-
-        Postconditions:
-        - {shared_config_id} shared configuration exists but with updated attributes
+      description: Update a shared configuration
       is: [withRequestItem: {item : SharedConfigPatch},
           withResponseItem: {item : SharedConfig}, withNotFoundError]
     /env_vars:
       get:
-        description: |
-          List all env variables belonging to {shared_config_id} shared config
-
-          Preconditions:
-          - {shared_config_id} shared configuration exists
-          - one of:
-            - Requester and {shared_config_id} shared configuration belong to the team
-              with at least {write} permission or
-            - Requester is owner
+        description: List environment variables belonging to a shared configuration
         is: [withResponseItems: {item : EnvVar}, withNotFoundError]
       post:
-        description: |
-          Create environment variable within {shared_config_id} shared config
-
-          Preconditions:
-          - {shared_config_id} shared configuration exists
-          - shared environment variable with {name} defined in the body does not exist
-          - one of:
-            - Requester and {shared_config_id} shared configuration belong to the team
-              with {admin} permission or
-            - Requester is owner
-
-          Postconditions:
-          - shared environment variable with {name} defined in the body exists
+        description: Create environment variable within a shared configuration
         is: [withRequestItem: {item : EnvVarPost},
             withResponseItem: {item : EnvVar}, withNotFoundError]
     /config_files:
       get:
-        description: |
-          List all shared config files belonging to {shared_config_id} shared config
-
-          Preconditions:
-          - {shared_config_id} shared configuration exists
-          - one of:
-            - Requester and {shared_config_id} shared configuration belong to the team
-              with at least {write} permission or
-            - Requester is owner
+        description: List config files belonging to a shared configuration
         is: [withResponseItems: {item : ConfigFile}, withNotFoundError]
       post:
-        description: |
-          Create shared config file within {shared_config_id} shared configuration
-
-          Preconditions:
-          - {shared_config_id} shared configuration exists
-          - shared config file with {path} defined in the body does not exist
-          - one of:
-            - Requester and {shared_config_id} shared configuration belong to the team
-              with {admin} permission or
-            - Requester is owner
-
-          Postconditions:
-          - shared environment variable with {path} defined in the body exists
+        description: Create a config file within a shared configuration
         is: [withRequestItem: {item : ConfigFilePost},
             withResponseItem: {item : ConfigFile}, withNotFoundError]
 
 /env_vars:
-  description: Manage Semaphore shared environment variables
   /{shared_env_var_id}:
     get:
-      description: |
-        Show {shared_env_var_id} shared env variable details
-
-        Preconditions:
-        - {shared_env_var_id} shared env variable exists
-        - one of:
-          - Requester and shared configuration that contains
-            {shared_env_var_id} shared env variable belong to the team
-            with at least {write} permission or
-          - Requester is owner
+      description: Get an environment variable
       is: [withResponseItem: {item : EnvVar}, withNotFoundError]
     delete:
-      description: |
-        Delete {shared_env_var_id} shared env variable
-
-        Preconditions:
-        - {shared_env_var_id} shared env variable exists
-        - {shared_env_var_id} shared env variable is not connected to any project
-        - one of:
-          - Requester and shared configuration that contains
-            {shared_env_var_id} shared env variable belong to the team
-            with {admin} permission or
-          - Requester is owner
-
-        Postconditions:
-        - {shared_env_var_id} shared env variable does not exist
+      description: Delete an environment variable
       is: [withNoBodyResponse, withNotFoundError]
     patch:
-      description: |
-        Update {shared_env_var_id} shared env variable
-
-        Preconditions:
-        - {shared_env_var_id} shared env variable exists
-        - one of:
-          - Requester and shared configuration that contains
-            {shared_env_var_id} shared env variable belong to the team
-            with {admin} permission or
-          - Requester is owner
-
-        Postconditions:
-        - {shared_env_var_id} shared env variable exists but with changed attributes
+      description: Update an environment variable
       is: [withRequestItem: {item : EnvVarPatch},
           withResponseItem: {item : EnvVar}, withNotFoundError]
 
 /config_files:
-  description: Manage Semaphore shared configuration files
   /{config_file_id}:
     get:
-      description: |
-        Show {config_file_id} shared config file details
-
-        Preconditions:
-        - {shared_conf_file_id} shared config file exists
-        - one of:
-          - Requester and shared configuration that contains
-            {shared_conf_file_id} shared config file belong to the team
-            with at least {write} permission or
-          - Requester is owner
+      description: Get a config file
       is: [withResponseItem: {item : ConfigFile}, withNotFoundError]
     delete:
-      description: |
-        Delete {config_file_id} shared config file
-
-        Preconditions:
-        - {shared_conf_file_id} config file exists
-        - {shared_conf_file_id} config file is not connected to any project
-        - one of:
-          - Requester and shared configuration that contains
-            {shared_conf_file_id} shared config file belong to the team
-            with {admin} permission or
-          - Requester is owner
-
-        Postconditions:
-        - {config_file_id} shared config file does not exist
+      description: Delete a config file
       is: [withNoBodyResponse, withNotFoundError]
     patch:
-      description: |
-        Update {config_file_id} config file
-
-        Preconditions:
-        - {config_file_id} shared config file exists
-        - one of:
-          - Requester and shared configuration that contains
-            {shared_conf_file_id} shared config filee belong to the team
-            with {admin} permission or
-          - Requester is owner
-
-        Postconditions:
-        - {config_file_id} config file exists but with changed attributes
+      description: Update a config file
       is: [withRequestItem: {item : ConfigFilePatch},
           withResponseItem: {item : ConfigFile}, withNotFoundError]


### PR DESCRIPTION
Changes in this PR:

#### 1) Removed all actions that are not implemented in the current sprint. These are:
   - /users
   - adding and removing projects from teams
   - /foo

#### 2) Introduced short names in the endpoints
   - `/shared-environment-variables` -> `/env_vars`
   - `/shared-configurations` -> `/shared_configs`
   - `/shared-configuration-files` -> `/config_files`

This also changes the semantics. For examples `/project/:project_id/env_vars` now 
returns all env vars.

#### 3) Changed dashes to underscores

e.g: `/shared-configs` is changed to `/shared_configs`.

#### 4) Shortened the names and removed parameter names:

eg. changed `Show {env_var_id} environment variable details` to `Get an environment variable`.

This style is shorter, easier to consume, and more DRY.

#### 5) Removed pre and post conditions

They are great, but we don't wan't to display them on the public documentation page. They will
remain accessible in the git history if we decide to show them somewhere else.