### PR TITLE
Move raml parser into API repo

### DIFF
--- a/raml_parser/.gitignore
+++ b/raml_parser/.gitignore
@@ -1,0 +1,12 @@
+/.bundle/
+/.yardoc
+/Gemfile.lock
+/_yardoc/
+/coverage/
+/doc/
+/pkg/
+/spec/reports/
+/tmp/
+
+# rspec failure tracking
+.rspec_status

--- a/raml_parser/.rspec
+++ b/raml_parser/.rspec
@@ -1,0 +1,2 @@
+--format documentation
+--color

--- a/raml_parser/Gemfile
+++ b/raml_parser/Gemfile
@@ -1,0 +1,4 @@
+source 'https://rubygems.org'
+
+# Specify your gem's dependencies in api_specs.gemspec
+gemspec

--- a/raml_parser/LICENSE.txt
+++ b/raml_parser/LICENSE.txt
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2017 Igor Šarčević
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/raml_parser/README.md
+++ b/raml_parser/README.md
@@ -1,0 +1,41 @@
+# RamlParser
+
+Welcome to your new gem! In this directory, you'll find the files you need to be able to package up your Ruby library into a gem. Put your Ruby code in the file `lib/api_specs`. To experiment with that code, run `bin/console` for an interactive prompt.
+
+TODO: Delete this and the text above, and describe your gem
+
+## Installation
+
+Add this line to your application's Gemfile:
+
+```ruby
+gem 'api_specs'
+```
+
+And then execute:
+
+    $ bundle
+
+Or install it yourself as:
+
+    $ gem install api_specs
+
+## Usage
+
+TODO: Write usage instructions here
+
+## Development
+
+After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
+
+To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
+
+## Contributing
+
+Bug reports and pull requests are welcome on GitHub at https://github.com/[USERNAME]/api_specs. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct.
+
+
+## License
+
+The gem is available as open source under the terms of the [MIT License](http://opensource.org/licenses/MIT).
+

--- a/raml_parser/Rakefile
+++ b/raml_parser/Rakefile
@@ -1,0 +1,6 @@
+require "bundler/gem_tasks"
+require "rspec/core/rake_task"
+
+RSpec::Core::RakeTask.new(:spec)
+
+task :default => :spec

--- a/raml_parser/bin/console
+++ b/raml_parser/bin/console
@@ -1,0 +1,14 @@
+#!/usr/bin/env ruby
+
+require "bundler/setup"
+require "api_specs"
+
+# You can add fixtures and/or initialization code here to make experimenting
+# with your gem easier. You can also use a different console, if you like.
+
+# (If you use this, don't forget to add pry to your Gemfile!)
+# require "pry"
+# Pry.start
+
+require "irb"
+IRB.start(__FILE__)

--- a/raml_parser/bin/setup
+++ b/raml_parser/bin/setup
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
+set -vx
+
+bundle install
+
+# Do any other automated setup that you need to do here

--- a/raml_parser/lib/raml_parser.rb
+++ b/raml_parser/lib/raml_parser.rb
@@ -1,0 +1,33 @@
+require "json"
+
+class RamlParser
+  require_relative "raml_parser/version"
+  require_relative "raml_parser/parser"
+  require_relative "raml_parser/route"
+  require_relative "raml_parser/resource"
+  require_relative "raml_parser/response"
+  require_relative "raml_parser/body"
+
+  def self.load(path)
+    new(JSON.parse(File.read(path)))
+  end
+
+  def initialize(raml_specs)
+    @raml_specs = RamlParser::Parser.new(raml_specs)
+  end
+
+  def resources
+    @resources ||= @raml_specs.top_level_resources
+  end
+
+  def find_resource_by_name(resource_name)
+    resources.find { |r| r.name == resource_name }
+  end
+
+  def find_route(verb, path)
+    resources.map(&:routes).flatten.find do |route|
+      route.verb == verb.to_s.upcase && route.path == path
+    end
+  end
+
+end

--- a/raml_parser/lib/raml_parser/body.rb
+++ b/raml_parser/lib/raml_parser/body.rb
@@ -1,0 +1,46 @@
+class RamlParser
+  class Body
+
+    def initialize(raw)
+      @raw = raw
+    end
+
+    def required?
+      @raw["required"]
+    end
+
+    def type
+      @raw["type"]
+    end
+
+    def name
+      @raw["key"]
+    end
+
+    def properties
+      @raw["properties"].map { |field| self.class.new(field) }
+    end
+
+    def structure
+      case type
+      when "array"  then [ self.class.new(@raw["items"]).structure]
+      when "object" then properties.map { |e| [e.name, e.type] }.to_h
+      end
+    end
+
+    def example
+      case type
+      when "array"    then [ self.class.new(@raw["items"]).example ]
+      when "object"   then properties.map { |e| [e.name, e.example] }.to_h
+      when "datetime" then "2017-06-10 16:59:51 +0200"
+      else
+        if @raw["example"]
+          @raw["example"]
+        elsif @raw["examples"] && @raw["examples"].first
+          @raw["examples"].first["structuredValue"]
+        end
+      end
+    end
+
+  end
+end

--- a/raml_parser/lib/raml_parser/parser.rb
+++ b/raml_parser/lib/raml_parser/parser.rb
@@ -1,0 +1,56 @@
+class RamlParser
+  class Parser
+    attr_reader :specs
+
+    def initialize(specs)
+      @specs = specs
+    end
+
+    def top_level_resources
+      specs["resources"].map do |resource|
+        name = resource["relativeUri"][1..-1]
+        display_name = resource["displayName"]
+
+        routes = all_routes.select { |r| r.resource_name == name }
+
+        Resource.new(name, display_name, routes)
+      end
+    end
+
+    def all_resources
+      find_resources(specs["resources"])
+    end
+
+    def all_routes
+      grouped_resources = all_resources.group_by do |resource|
+        path = resource["absoluteUri"].gsub(@specs["baseUri"], "")
+
+        segments = path.split("/")
+
+        segments.size < 4 ? segments[1] : segments[3]
+      end
+
+      grouped_resources.map do |resource_name, resources|
+        resources.map do |resource|
+          (resource["methods"] || []).map do |method|
+            path = resource["absoluteUri"].gsub(@specs["baseUri"], "")
+
+            Route.new(path, resource_name, resource, method)
+          end
+        end.flatten
+      end.flatten
+    end
+
+    private
+
+    def find_resources(node)
+      if node.is_a?(Array)
+        node.map { |r| find_resources(r) }.flatten
+      elsif node.is_a?(Hash)
+        [node] + find_resources(node["resources"])
+      else
+        []
+      end
+    end
+  end
+end

--- a/raml_parser/lib/raml_parser/resource.rb
+++ b/raml_parser/lib/raml_parser/resource.rb
@@ -1,0 +1,43 @@
+class RamlParser
+  class Resource
+
+    attr_reader :name
+    attr_reader :display_name
+    attr_reader :routes
+
+    def initialize(name, display_name, routes)
+      @name = name
+      @display_name = display_name
+      @routes = routes
+    end
+
+    def index
+      routes.select(&:index?)
+    end
+
+    def show
+      routes.select(&:show?)
+    end
+
+    def create
+      routes.select(&:create?)
+    end
+
+    def update
+      routes.select(&:update?)
+    end
+
+    def delete
+      routes.select(&:delete?)
+    end
+
+    def connect
+      routes.select(&:connect?)
+    end
+
+    def dissconnect
+      routes.select(&:dissconnect?)
+    end
+
+  end
+end

--- a/raml_parser/lib/raml_parser/response.rb
+++ b/raml_parser/lib/raml_parser/response.rb
@@ -1,0 +1,37 @@
+class RamlParser
+  class Response
+    def initialize(raml_response)
+      @raml_response = raml_response
+    end
+
+    def code
+      @raml_response["code"].to_i
+    end
+
+    def succesfull?
+      code >= 200 && code < 300
+    end
+
+    def empty?
+      @raml_response["body"].nil?
+    end
+
+    def body
+      return nil if empty?
+
+      RamlParser::Body.new(@raml_response["body"].first)
+    end
+
+    def example
+      return nil if empty?
+
+      body.example
+    end
+
+    def structure
+      return nil if empty?
+
+      body.structure
+    end
+  end
+end

--- a/raml_parser/lib/raml_parser/route.rb
+++ b/raml_parser/lib/raml_parser/route.rb
@@ -1,0 +1,91 @@
+class RamlParser
+  class Route
+
+    attr_reader :resource_name
+    attr_reader :path
+
+    def initialize(path, resource_name, raml_resource, raml_method)
+      @path = path
+      @resource_name = resource_name
+      @raml_resource = raml_resource
+      @raml_method = raml_method
+    end
+
+    def display_name
+      @raml_method["displayName"]
+    end
+
+    def description
+      @raml_method["description"]
+    end
+
+    def verb
+      @raml_method["method"].upcase
+    end
+
+    def verb_and_path
+      "#{verb} #{path}"
+    end
+
+    def request
+      return nil unless @raml_method["body"]
+
+      @request ||= Body.new(@raml_method["body"].first)
+    end
+
+    def responses
+      @resources ||= @raml_method["responses"].map { |r| Response.new(r) }
+    end
+
+    def succesfull_response
+      responses.find(&:succesfull?)
+    end
+
+    def index?
+      verb == "GET" && collection_route?
+    end
+
+    def show?
+      verb == "GET" && member_route?
+    end
+
+    def create?
+      verb == "POST" && collection_route?
+    end
+
+    def update?
+      verb == "PATCH" && member_route?
+    end
+
+    def delete?
+      verb == "DELETE" && member_route?
+    end
+
+    def connect?
+      verb == "POST" && connection_route?
+    end
+
+    def dissconnect?
+      verb == "DELETE" && connection_route?
+    end
+
+    private
+
+    def member_route?
+      !connection_route? && path_ends_with_a_param?
+    end
+
+    def collection_route?
+      !connection_route? && !path_ends_with_a_param?
+    end
+
+    def connection_route?
+      path.split("/").count == 5
+    end
+
+    def path_ends_with_a_param?
+      path[-1] == "}"
+    end
+
+  end
+end

--- a/raml_parser/lib/raml_parser/version.rb
+++ b/raml_parser/lib/raml_parser/version.rb
@@ -1,0 +1,3 @@
+class RamlParser
+  VERSION = "0.4.0"
+end

--- a/raml_parser/raml_parser.gemspec
+++ b/raml_parser/raml_parser.gemspec
@@ -1,0 +1,26 @@
+# coding: utf-8
+lib = File.expand_path('../lib', __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require 'raml_parser/version'
+
+Gem::Specification.new do |spec|
+  spec.name          = "raml_parser"
+  spec.version       = RamlParser::VERSION
+  spec.authors       = ["Igor Šarčević"]
+  spec.email         = ["igor@renderedtext.com"]
+
+  spec.summary       = %q{Parse raml object files}
+  spec.description   = %q{Parse raml object files}
+
+  spec.files         = `git ls-files -z`.split("\x0").reject do |f|
+    f.match(%r{^(test|spec|features)/})
+  end
+  spec.bindir        = "exe"
+  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
+  spec.require_paths = ["lib"]
+
+  spec.add_development_dependency "bundler", "~> 1.14"
+  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "rspec", "~> 3.0"
+  spec.add_development_dependency "byebug"
+end

--- a/raml_parser/spec/raml_parser_spec.rb
+++ b/raml_parser/spec/raml_parser_spec.rb
@@ -1,0 +1,144 @@
+require "spec_helper"
+require "byebug"
+
+RSpec.describe RamlParser do
+
+  it "has a version number" do
+    expect(RamlParser::VERSION).not_to be nil
+  end
+
+  let(:specs) { RamlParser.load("spec/specs.json") }
+  let(:shared_configs) { specs.find_resource_by_name("shared_configs") }
+
+  it "can list resource display names" do
+    expect(specs.resources.map(&:name)).to match_array [
+      "orgs",
+      "config_files",
+      "env_vars",
+      "projects",
+      "shared_configs",
+      "teams",
+      "users"
+    ]
+  end
+
+  it "can list resource display names" do
+    expect(specs.resources.map(&:display_name)).to match_array [
+      "Organizations",
+      "Configuration Files",
+      "Environment Variables",
+      "Projects",
+      "Shared Configurations",
+      "Teams",
+      "Users"
+    ]
+  end
+
+  it "can display route descriptions" do
+    expect(shared_configs.routes.map(&:display_name)).to include("Add a shared configuration to a team")
+  end
+
+  it "can list index routes" do
+    expect(shared_configs.index.map(&:verb_and_path)).to match_array [
+      "GET /orgs/{org_username}/shared_configs",
+      "GET /teams/{team_id}/shared_configs",
+      "GET /projects/{project_id}/shared_configs",
+    ]
+  end
+
+  it "can list show routes" do
+    expect(shared_configs.show.map(&:verb_and_path)).to match_array [ "GET /shared_configs/{id}" ]
+  end
+
+  it "can list create routes" do
+    expect(shared_configs.create.map(&:verb_and_path)).to match_array [ "POST /orgs/{org_username}/shared_configs" ]
+  end
+
+  it "can list delete routes" do
+    expect(shared_configs.delete.map(&:verb_and_path)).to match_array [ "DELETE /shared_configs/{id}" ]
+  end
+
+  it "can list update routes" do
+    expect(shared_configs.update.map(&:verb_and_path)).to match_array [ "PATCH /shared_configs/{id}" ]
+  end
+
+  it "can list connect routes" do
+    expect(shared_configs.connect.map(&:verb_and_path)).to match_array [
+      "POST /teams/{team_id}/shared_configs/{shared_config_id}",
+      "POST /projects/{project_id}/shared_configs/{shared_config_id}"
+    ]
+  end
+
+  it "can list dissconnect routes" do
+    expect(shared_configs.dissconnect.map(&:verb_and_path)).to match_array [
+      "DELETE /teams/{team_id}/shared_configs/{shared_config_id}",
+      "DELETE /projects/{project_id}/shared_configs/{shared_config_id}"
+    ]
+  end
+
+  it "can create example responses for show" do
+    get_shared_config = specs.find_route(:get, "/shared_configs/{id}")
+
+    expect(get_shared_config.responses.map(&:code)).to match_array([ 200, 404 ])
+
+    expect(get_shared_config.succesfull_response.example).to eq(
+      "id" => "86e78b7e-2f9c-45a7-9939-ec2c9f6f64b5",
+      "description" => "AWS tokens for deployment",
+      "url" => "https://api.semaphoreci.com/v2/shared_configs/86e78b7e-2f9c-45a7-9939-ec2c9f6f64b5",
+      "name" => "AWS Tokens",
+      "updated_at" => "2017-06-10 16:59:51 +0200",
+      "created_at" => "2017-06-10 16:59:51 +0200"
+    )
+  end
+
+  it "can create example response for delete" do
+    delete_shared_config = specs.find_route(:delete, "/shared_configs/{id}")
+
+    expect(delete_shared_config.responses.map(&:code)).to match_array([ 204, 404 ])
+    expect(delete_shared_config.succesfull_response.example).to eq(nil)
+  end
+
+  it "can create example response for index" do
+    index = specs.find_route(:get, "/projects/{project_id}/config_files")
+
+    expect(index.responses.map(&:code)).to match_array([ 200, 404 ])
+
+    expect(index.succesfull_response.example).to eq([
+      {
+        "id" => "86e78b7e-2f9c-45a7-9939-ec2c9f6f64b5",
+        "path"=> ".credentials",
+        "url" => "https://api.semaphoreci.com/v2/config_files/86e78b7e-2f9c-45a7-9939-ec2c9f6f64b5",
+        "content" => "password: ec2c9f6f64b5",
+        "encrypted" => true,
+        "shared" => true,
+        "updated_at" => "2017-06-10 16:59:51 +0200",
+        "created_at" => "2017-06-10 16:59:51 +0200"
+      }
+    ])
+  end
+
+  it "can list request params" do
+    patch_shared_config = specs.find_route(:patch, "/shared_configs/{id}")
+
+    expect(patch_shared_config.request.example).to eq({
+      "description" => "AWS tokens for deployment",
+      "name" => "AWS Tokens"
+    })
+  end
+
+  it "can display the structure of the response" do
+    index_shared_config = specs.find_route(:get, "/projects/{project_id}/shared_configs")
+
+    expect(index_shared_config.succesfull_response.structure).to eq([
+      {
+        "id" => "string",
+        "description" => "string",
+        "url" => "string",
+        "name" => "string",
+        "updated_at" => "datetime",
+        "created_at" => "datetime"
+      }
+    ])
+  end
+
+end

--- a/raml_parser/spec/spec_helper.rb
+++ b/raml_parser/spec/spec_helper.rb
@@ -1,0 +1,11 @@
+require "bundler/setup"
+require "raml_parser"
+
+RSpec.configure do |config|
+  # Enable flags like --only-failures and --next-failure
+  config.example_status_persistence_file_path = ".rspec_status"
+
+  config.expect_with :rspec do |c|
+    c.syntax = :expect
+  end
+end

--- a/raml_parser/spec/specs.json
+++ b/raml_parser/spec/specs.json
@@ -1,0 +1,7317 @@
+{
+  "traits": {
+    "withRequestItem": {
+      "body": [
+        {
+          "name": "application/json",
+          "displayName": "application/json",
+          "typePropertyKind": "TYPE_EXPRESSION",
+          "type": "<<item>>",
+          "key": "application/json"
+        }
+      ],
+      "name": "withRequestItem"
+    },
+    "withResponseItem": {
+      "responses": [
+        {
+          "code": "200",
+          "body": [
+            {
+              "name": "application/json",
+              "displayName": "application/json",
+              "typePropertyKind": "TYPE_EXPRESSION",
+              "type": "<<item>>",
+              "key": "application/json"
+            }
+          ],
+          "key": "200"
+        }
+      ],
+      "name": "withResponseItem"
+    },
+    "withResponseItems": {
+      "responses": [
+        {
+          "code": "200",
+          "body": [
+            {
+              "name": "application/json",
+              "displayName": "application/json",
+              "typePropertyKind": "TYPE_EXPRESSION",
+              "type": "<<item>>[]",
+              "key": "application/json"
+            }
+          ],
+          "key": "200"
+        }
+      ],
+      "name": "withResponseItems"
+    },
+    "withCreateResponse": {
+      "responses": [
+        {
+          "code": "201",
+          "body": [
+            {
+              "name": "application/json",
+              "displayName": "application/json",
+              "typePropertyKind": "TYPE_EXPRESSION",
+              "type": "<<item>>",
+              "key": "application/json"
+            }
+          ],
+          "key": "201"
+        }
+      ],
+      "name": "withCreateResponse"
+    },
+    "withNoBodyResponse": {
+      "responses": [
+        {
+          "code": "204",
+          "key": "204"
+        }
+      ],
+      "name": "withNoBodyResponse"
+    },
+    "withClientError": {
+      "responses": [
+        {
+          "code": "400",
+          "body": [
+            {
+              "name": "Error",
+              "displayName": "Error",
+              "typePropertyKind": "TYPE_EXPRESSION",
+              "type": "object",
+              "additionalProperties": true,
+              "properties": [
+                {
+                  "type": "string",
+                  "displayName": "message",
+                  "name": "message",
+                  "typePropertyKind": "TYPE_EXPRESSION",
+                  "required": true,
+                  "key": "message"
+                }
+              ],
+              "key": "application/json"
+            }
+          ],
+          "key": "400"
+        }
+      ],
+      "name": "withClientError"
+    },
+    "withNotFoundError": {
+      "responses": [
+        {
+          "code": "404",
+          "body": [
+            {
+              "name": "Error",
+              "displayName": "Error",
+              "typePropertyKind": "TYPE_EXPRESSION",
+              "type": "object",
+              "additionalProperties": true,
+              "properties": [
+                {
+                  "type": "string",
+                  "displayName": "message",
+                  "name": "message",
+                  "typePropertyKind": "TYPE_EXPRESSION",
+                  "required": true,
+                  "key": "message"
+                }
+              ],
+              "key": "application/json"
+            }
+          ],
+          "key": "404"
+        }
+      ],
+      "name": "withNotFoundError"
+    },
+    "withPreconditionFailedError": {
+      "responses": [
+        {
+          "code": "412",
+          "body": [
+            {
+              "name": "Error",
+              "displayName": "Error",
+              "typePropertyKind": "TYPE_EXPRESSION",
+              "type": "object",
+              "additionalProperties": true,
+              "properties": [
+                {
+                  "type": "string",
+                  "displayName": "message",
+                  "name": "message",
+                  "typePropertyKind": "TYPE_EXPRESSION",
+                  "required": true,
+                  "key": "message"
+                }
+              ],
+              "key": "application/json"
+            }
+          ],
+          "key": "412"
+        }
+      ],
+      "name": "withPreconditionFailedError"
+    }
+  },
+  "title": "Semaphore",
+  "version": "v2",
+  "baseUri": "https://api.semaphoreci.com/v2",
+  "protocols": [
+    "HTTPS"
+  ],
+  "mediaType": "application/json",
+  "resources": [
+    {
+      "relativeUri": "/users",
+      "displayName": "Users",
+      "relativeUriPathSegments": [
+        "users"
+      ],
+      "absoluteUri": "https://api.semaphoreci.com/v2/users",
+      "parentUrl": "",
+      "uniqueId": "users",
+      "allUriParameters": []
+    },
+    {
+      "methods": [
+        {
+          "responses": [
+            {
+              "code": "200",
+              "body": [
+                {
+                  "name": "application/json",
+                  "displayName": "application/json",
+                  "typePropertyKind": "TYPE_EXPRESSION",
+                  "type": "array",
+                  "items": {
+                    "additionalProperties": true,
+                    "type": "object",
+                    "displayName": "Org",
+                    "name": "Org",
+                    "typePropertyKind": "TYPE_EXPRESSION",
+                    "properties": [
+                      {
+                        "displayName": "id",
+                        "type": "string",
+                        "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
+                        "name": "id",
+                        "typePropertyKind": "TYPE_EXPRESSION",
+                        "required": true,
+                        "examples": [
+                          {
+                            "value": "86e78b7e-2f9c-45a7-9939-ec2c9f6f64b5",
+                            "strict": true,
+                            "structuredValue": "86e78b7e-2f9c-45a7-9939-ec2c9f6f64b5"
+                          }
+                        ],
+                        "key": "id"
+                      },
+                      {
+                        "type": "string",
+                        "displayName": "name",
+                        "name": "name",
+                        "typePropertyKind": "TYPE_EXPRESSION",
+                        "required": true,
+                        "examples": [
+                          {
+                            "value": "Rendered Text",
+                            "strict": true,
+                            "structuredValue": "Rendered Text"
+                          }
+                        ],
+                        "key": "name"
+                      },
+                      {
+                        "type": "string",
+                        "displayName": "url",
+                        "name": "url",
+                        "typePropertyKind": "TYPE_EXPRESSION",
+                        "required": true,
+                        "examples": [
+                          {
+                            "value": "https://api.semaphoreci.com/v2/teams/86e78b7e-2f9c-45a7-9939-ec2c9f6f64b5",
+                            "strict": true,
+                            "structuredValue": "https://api.semaphoreci.com/v2/teams/86e78b7e-2f9c-45a7-9939-ec2c9f6f64b5"
+                          }
+                        ],
+                        "key": "url"
+                      },
+                      {
+                        "type": "string",
+                        "displayName": "username",
+                        "name": "username",
+                        "typePropertyKind": "TYPE_EXPRESSION",
+                        "required": true,
+                        "examples": [
+                          {
+                            "value": "renderedtext",
+                            "strict": true,
+                            "structuredValue": "renderedtext"
+                          }
+                        ],
+                        "key": "username"
+                      },
+                      {
+                        "format": "rfc3339",
+                        "displayName": "created_at",
+                        "type": "datetime",
+                        "name": "created_at",
+                        "typePropertyKind": "TYPE_EXPRESSION",
+                        "required": true,
+                        "key": "created_at"
+                      },
+                      {
+                        "format": "rfc3339",
+                        "displayName": "updated_at",
+                        "type": "datetime",
+                        "name": "updated_at",
+                        "typePropertyKind": "TYPE_EXPRESSION",
+                        "required": true,
+                        "key": "updated_at"
+                      }
+                    ]
+                  },
+                  "key": "application/json"
+                }
+              ],
+              "key": "200"
+            }
+          ],
+          "protocols": [
+            "HTTPS"
+          ],
+          "is": [
+            {
+              "withResponseItems": {
+                "item": "Org"
+              }
+            }
+          ],
+          "displayName": "List your organizations",
+          "method": "get",
+          "allUriParameters": []
+        }
+      ],
+      "relativeUri": "/orgs",
+      "displayName": "Organizations",
+      "resources": [
+        {
+          "methods": [
+            {
+              "responses": [
+                {
+                  "code": "200",
+                  "body": [
+                    {
+                      "name": "Org",
+                      "displayName": "Org",
+                      "typePropertyKind": "TYPE_EXPRESSION",
+                      "type": "object",
+                      "additionalProperties": true,
+                      "properties": [
+                        {
+                          "displayName": "id",
+                          "type": "string",
+                          "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
+                          "name": "id",
+                          "typePropertyKind": "TYPE_EXPRESSION",
+                          "required": true,
+                          "examples": [
+                            {
+                              "value": "86e78b7e-2f9c-45a7-9939-ec2c9f6f64b5",
+                              "strict": true,
+                              "structuredValue": "86e78b7e-2f9c-45a7-9939-ec2c9f6f64b5"
+                            }
+                          ],
+                          "key": "id"
+                        },
+                        {
+                          "type": "string",
+                          "displayName": "name",
+                          "name": "name",
+                          "typePropertyKind": "TYPE_EXPRESSION",
+                          "required": true,
+                          "examples": [
+                            {
+                              "value": "Rendered Text",
+                              "strict": true,
+                              "structuredValue": "Rendered Text"
+                            }
+                          ],
+                          "key": "name"
+                        },
+                        {
+                          "type": "string",
+                          "displayName": "url",
+                          "name": "url",
+                          "typePropertyKind": "TYPE_EXPRESSION",
+                          "required": true,
+                          "examples": [
+                            {
+                              "value": "https://api.semaphoreci.com/v2/teams/86e78b7e-2f9c-45a7-9939-ec2c9f6f64b5",
+                              "strict": true,
+                              "structuredValue": "https://api.semaphoreci.com/v2/teams/86e78b7e-2f9c-45a7-9939-ec2c9f6f64b5"
+                            }
+                          ],
+                          "key": "url"
+                        },
+                        {
+                          "type": "string",
+                          "displayName": "username",
+                          "name": "username",
+                          "typePropertyKind": "TYPE_EXPRESSION",
+                          "required": true,
+                          "examples": [
+                            {
+                              "value": "renderedtext",
+                              "strict": true,
+                              "structuredValue": "renderedtext"
+                            }
+                          ],
+                          "key": "username"
+                        },
+                        {
+                          "format": "rfc3339",
+                          "displayName": "created_at",
+                          "type": "datetime",
+                          "name": "created_at",
+                          "typePropertyKind": "TYPE_EXPRESSION",
+                          "required": true,
+                          "key": "created_at"
+                        },
+                        {
+                          "format": "rfc3339",
+                          "displayName": "updated_at",
+                          "type": "datetime",
+                          "name": "updated_at",
+                          "typePropertyKind": "TYPE_EXPRESSION",
+                          "required": true,
+                          "key": "updated_at"
+                        }
+                      ],
+                      "key": "application/json"
+                    }
+                  ],
+                  "key": "200"
+                },
+                {
+                  "code": "404",
+                  "body": [
+                    {
+                      "name": "Error",
+                      "displayName": "Error",
+                      "typePropertyKind": "TYPE_EXPRESSION",
+                      "type": "object",
+                      "additionalProperties": true,
+                      "properties": [
+                        {
+                          "type": "string",
+                          "displayName": "message",
+                          "name": "message",
+                          "typePropertyKind": "TYPE_EXPRESSION",
+                          "required": true,
+                          "key": "message"
+                        }
+                      ],
+                      "key": "application/json"
+                    }
+                  ],
+                  "key": "404"
+                }
+              ],
+              "protocols": [
+                "HTTPS"
+              ],
+              "is": [
+                {
+                  "withResponseItem": {
+                    "item": "Org"
+                  }
+                },
+                "withNotFoundError"
+              ],
+              "displayName": "Get an organization",
+              "method": "get",
+              "allUriParameters": [
+                {
+                  "name": "username",
+                  "displayName": "username",
+                  "typePropertyKind": "TYPE_EXPRESSION",
+                  "type": "string",
+                  "required": true,
+                  "key": "username"
+                }
+              ]
+            }
+          ],
+          "uriParameters": [
+            {
+              "name": "username",
+              "displayName": "username",
+              "typePropertyKind": "TYPE_EXPRESSION",
+              "type": "string",
+              "required": true,
+              "key": "username"
+            }
+          ],
+          "relativeUri": "/{username}",
+          "displayName": "/{username}",
+          "relativeUriPathSegments": [
+            "{username}"
+          ],
+          "absoluteUri": "https://api.semaphoreci.com/v2/orgs/{username}",
+          "parentUrl": "/orgs",
+          "uniqueId": "orgs__username_",
+          "allUriParameters": [
+            {
+              "name": "username",
+              "displayName": "username",
+              "typePropertyKind": "TYPE_EXPRESSION",
+              "type": "string",
+              "required": true,
+              "key": "username"
+            }
+          ]
+        },
+        {
+          "uriParameters": [
+            {
+              "name": "org_username",
+              "displayName": "org_username",
+              "typePropertyKind": "TYPE_EXPRESSION",
+              "type": "string",
+              "required": true,
+              "key": "org_username"
+            }
+          ],
+          "relativeUri": "/{org_username}",
+          "displayName": "/{org_username}",
+          "resources": [
+            {
+              "methods": [
+                {
+                  "responses": [
+                    {
+                      "code": "200",
+                      "body": [
+                        {
+                          "name": "application/json",
+                          "displayName": "application/json",
+                          "typePropertyKind": "TYPE_EXPRESSION",
+                          "type": "array",
+                          "items": {
+                            "additionalProperties": true,
+                            "displayName": "Team",
+                            "type": "object",
+                            "name": "Team",
+                            "typePropertyKind": "TYPE_EXPRESSION",
+                            "properties": [
+                              {
+                                "displayName": "name",
+                                "type": "string",
+                                "example": "developers",
+                                "required": true,
+                                "key": "name"
+                              },
+                              {
+                                "enum": [
+                                  "read",
+                                  "write",
+                                  "admin"
+                                ],
+                                "displayName": "permission",
+                                "type": "string",
+                                "example": "write",
+                                "required": true,
+                                "key": "permission"
+                              },
+                              {
+                                "displayName": "description",
+                                "type": "string",
+                                "example": "Developers team",
+                                "required": false,
+                                "key": "description"
+                              },
+                              {
+                                "displayName": "id",
+                                "type": "string",
+                                "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
+                                "name": "id",
+                                "typePropertyKind": "TYPE_EXPRESSION",
+                                "required": true,
+                                "examples": [
+                                  {
+                                    "value": "86e78b7e-2f9c-45a7-9939-ec2c9f6f64b5",
+                                    "strict": true,
+                                    "structuredValue": "86e78b7e-2f9c-45a7-9939-ec2c9f6f64b5"
+                                  }
+                                ],
+                                "key": "id"
+                              },
+                              {
+                                "type": "string",
+                                "displayName": "url",
+                                "name": "url",
+                                "typePropertyKind": "TYPE_EXPRESSION",
+                                "required": true,
+                                "examples": [
+                                  {
+                                    "value": "https://api.semaphoreci.com/v2/teams/86e78b7e-2f9c-45a7-9939-ec2c9f6f64b5",
+                                    "strict": true,
+                                    "structuredValue": "https://api.semaphoreci.com/v2/teams/86e78b7e-2f9c-45a7-9939-ec2c9f6f64b5"
+                                  }
+                                ],
+                                "key": "url"
+                              },
+                              {
+                                "format": "rfc3339",
+                                "displayName": "updated_at",
+                                "type": "datetime",
+                                "name": "updated_at",
+                                "typePropertyKind": "TYPE_EXPRESSION",
+                                "required": true,
+                                "key": "updated_at"
+                              },
+                              {
+                                "format": "rfc3339",
+                                "displayName": "created_at",
+                                "type": "datetime",
+                                "name": "created_at",
+                                "typePropertyKind": "TYPE_EXPRESSION",
+                                "required": true,
+                                "key": "created_at"
+                              }
+                            ]
+                          },
+                          "key": "application/json"
+                        }
+                      ],
+                      "key": "200"
+                    }
+                  ],
+                  "protocols": [
+                    "HTTPS"
+                  ],
+                  "is": [
+                    {
+                      "withResponseItems": {
+                        "item": "Team"
+                      }
+                    }
+                  ],
+                  "displayName": "List teams in an organization",
+                  "method": "get",
+                  "allUriParameters": [
+                    {
+                      "name": "org_username",
+                      "displayName": "org_username",
+                      "typePropertyKind": "TYPE_EXPRESSION",
+                      "type": "string",
+                      "required": true,
+                      "key": "org_username"
+                    }
+                  ]
+                },
+                {
+                  "responses": [
+                    {
+                      "code": "200",
+                      "body": [
+                        {
+                          "name": "Team",
+                          "displayName": "Team",
+                          "typePropertyKind": "TYPE_EXPRESSION",
+                          "type": "object",
+                          "additionalProperties": true,
+                          "properties": [
+                            {
+                              "displayName": "name",
+                              "type": "string",
+                              "example": "developers",
+                              "required": true,
+                              "key": "name"
+                            },
+                            {
+                              "enum": [
+                                "read",
+                                "write",
+                                "admin"
+                              ],
+                              "displayName": "permission",
+                              "type": "string",
+                              "example": "write",
+                              "required": true,
+                              "key": "permission"
+                            },
+                            {
+                              "displayName": "description",
+                              "type": "string",
+                              "example": "Developers team",
+                              "required": false,
+                              "key": "description"
+                            },
+                            {
+                              "displayName": "id",
+                              "type": "string",
+                              "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
+                              "name": "id",
+                              "typePropertyKind": "TYPE_EXPRESSION",
+                              "required": true,
+                              "examples": [
+                                {
+                                  "value": "86e78b7e-2f9c-45a7-9939-ec2c9f6f64b5",
+                                  "strict": true,
+                                  "structuredValue": "86e78b7e-2f9c-45a7-9939-ec2c9f6f64b5"
+                                }
+                              ],
+                              "key": "id"
+                            },
+                            {
+                              "type": "string",
+                              "displayName": "url",
+                              "name": "url",
+                              "typePropertyKind": "TYPE_EXPRESSION",
+                              "required": true,
+                              "examples": [
+                                {
+                                  "value": "https://api.semaphoreci.com/v2/teams/86e78b7e-2f9c-45a7-9939-ec2c9f6f64b5",
+                                  "strict": true,
+                                  "structuredValue": "https://api.semaphoreci.com/v2/teams/86e78b7e-2f9c-45a7-9939-ec2c9f6f64b5"
+                                }
+                              ],
+                              "key": "url"
+                            },
+                            {
+                              "format": "rfc3339",
+                              "displayName": "updated_at",
+                              "type": "datetime",
+                              "name": "updated_at",
+                              "typePropertyKind": "TYPE_EXPRESSION",
+                              "required": true,
+                              "key": "updated_at"
+                            },
+                            {
+                              "format": "rfc3339",
+                              "displayName": "created_at",
+                              "type": "datetime",
+                              "name": "created_at",
+                              "typePropertyKind": "TYPE_EXPRESSION",
+                              "required": true,
+                              "key": "created_at"
+                            }
+                          ],
+                          "key": "application/json"
+                        }
+                      ],
+                      "key": "200"
+                    },
+                    {
+                      "code": "404",
+                      "body": [
+                        {
+                          "name": "Error",
+                          "displayName": "Error",
+                          "typePropertyKind": "TYPE_EXPRESSION",
+                          "type": "object",
+                          "additionalProperties": true,
+                          "properties": [
+                            {
+                              "type": "string",
+                              "displayName": "message",
+                              "name": "message",
+                              "typePropertyKind": "TYPE_EXPRESSION",
+                              "required": true,
+                              "key": "message"
+                            }
+                          ],
+                          "key": "application/json"
+                        }
+                      ],
+                      "key": "404"
+                    },
+                    {
+                      "code": "412",
+                      "body": [
+                        {
+                          "name": "Error",
+                          "displayName": "Error",
+                          "typePropertyKind": "TYPE_EXPRESSION",
+                          "type": "object",
+                          "additionalProperties": true,
+                          "properties": [
+                            {
+                              "type": "string",
+                              "displayName": "message",
+                              "name": "message",
+                              "typePropertyKind": "TYPE_EXPRESSION",
+                              "required": true,
+                              "key": "message"
+                            }
+                          ],
+                          "key": "application/json"
+                        }
+                      ],
+                      "key": "412"
+                    }
+                  ],
+                  "body": [
+                    {
+                      "name": "TeamPost",
+                      "displayName": "TeamPost",
+                      "typePropertyKind": "TYPE_EXPRESSION",
+                      "type": "object",
+                      "additionalProperties": true,
+                      "properties": [
+                        {
+                          "type": "string",
+                          "displayName": "name",
+                          "name": "name",
+                          "typePropertyKind": "TYPE_EXPRESSION",
+                          "required": true,
+                          "examples": [
+                            {
+                              "value": "developers",
+                              "strict": true,
+                              "structuredValue": "developers"
+                            }
+                          ],
+                          "key": "name"
+                        },
+                        {
+                          "type": "string",
+                          "enum": [
+                            "read",
+                            "write",
+                            "admin"
+                          ],
+                          "displayName": "permission",
+                          "name": "permission",
+                          "typePropertyKind": "TYPE_EXPRESSION",
+                          "required": true,
+                          "examples": [
+                            {
+                              "value": "write",
+                              "strict": true,
+                              "structuredValue": "write"
+                            }
+                          ],
+                          "key": "permission"
+                        },
+                        {
+                          "type": "string",
+                          "displayName": "description",
+                          "name": "description",
+                          "typePropertyKind": "TYPE_EXPRESSION",
+                          "required": false,
+                          "examples": [
+                            {
+                              "value": "Developers team",
+                              "strict": true,
+                              "structuredValue": "Developers team"
+                            }
+                          ],
+                          "key": "description"
+                        }
+                      ],
+                      "key": "application/json"
+                    }
+                  ],
+                  "protocols": [
+                    "HTTPS"
+                  ],
+                  "is": [
+                    {
+                      "withRequestItem": {
+                        "item": "TeamPost"
+                      }
+                    },
+                    {
+                      "withResponseItem": {
+                        "item": "Team"
+                      }
+                    },
+                    "withNotFoundError",
+                    "withPreconditionFailedError"
+                  ],
+                  "displayName": "Create a team in an organization",
+                  "method": "post",
+                  "allUriParameters": [
+                    {
+                      "name": "org_username",
+                      "displayName": "org_username",
+                      "typePropertyKind": "TYPE_EXPRESSION",
+                      "type": "string",
+                      "required": true,
+                      "key": "org_username"
+                    }
+                  ]
+                }
+              ],
+              "relativeUri": "/teams",
+              "displayName": "/teams",
+              "relativeUriPathSegments": [
+                "teams"
+              ],
+              "absoluteUri": "https://api.semaphoreci.com/v2/orgs/{org_username}/teams",
+              "parentUrl": "/orgs/{org_username}",
+              "uniqueId": "orgs__org_username__teams",
+              "allUriParameters": [
+                {
+                  "name": "org_username",
+                  "displayName": "org_username",
+                  "typePropertyKind": "TYPE_EXPRESSION",
+                  "type": "string",
+                  "required": true,
+                  "key": "org_username"
+                }
+              ]
+            },
+            {
+              "methods": [
+                {
+                  "responses": [
+                    {
+                      "code": "200",
+                      "body": [
+                        {
+                          "name": "application/json",
+                          "displayName": "application/json",
+                          "typePropertyKind": "TYPE_EXPRESSION",
+                          "type": "array",
+                          "items": {
+                            "additionalProperties": true,
+                            "type": "object",
+                            "displayName": "Project",
+                            "name": "Project",
+                            "typePropertyKind": "TYPE_EXPRESSION",
+                            "properties": [
+                              {
+                                "displayName": "id",
+                                "type": "string",
+                                "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
+                                "name": "id",
+                                "typePropertyKind": "TYPE_EXPRESSION",
+                                "required": true,
+                                "examples": [
+                                  {
+                                    "value": "86e78b7e-2f9c-45a7-9939-ec2c9f6f64b5",
+                                    "strict": true,
+                                    "structuredValue": "86e78b7e-2f9c-45a7-9939-ec2c9f6f64b5"
+                                  }
+                                ],
+                                "key": "id"
+                              },
+                              {
+                                "type": "string",
+                                "displayName": "name",
+                                "name": "name",
+                                "typePropertyKind": "TYPE_EXPRESSION",
+                                "required": true,
+                                "examples": [
+                                  {
+                                    "value": "elixir-lang",
+                                    "strict": true,
+                                    "structuredValue": "elixir-lang"
+                                  }
+                                ],
+                                "key": "name"
+                              },
+                              {
+                                "format": "rfc3339",
+                                "displayName": "updated_at",
+                                "type": "datetime",
+                                "name": "updated_at",
+                                "typePropertyKind": "TYPE_EXPRESSION",
+                                "required": true,
+                                "key": "updated_at"
+                              },
+                              {
+                                "format": "rfc3339",
+                                "displayName": "created_at",
+                                "type": "datetime",
+                                "name": "created_at",
+                                "typePropertyKind": "TYPE_EXPRESSION",
+                                "required": true,
+                                "key": "created_at"
+                              }
+                            ]
+                          },
+                          "key": "application/json"
+                        }
+                      ],
+                      "key": "200"
+                    }
+                  ],
+                  "protocols": [
+                    "HTTPS"
+                  ],
+                  "is": [
+                    {
+                      "withResponseItems": {
+                        "item": "Project"
+                      }
+                    }
+                  ],
+                  "displayName": "List projects in an organization",
+                  "method": "get",
+                  "allUriParameters": [
+                    {
+                      "name": "org_username",
+                      "displayName": "org_username",
+                      "typePropertyKind": "TYPE_EXPRESSION",
+                      "type": "string",
+                      "required": true,
+                      "key": "org_username"
+                    }
+                  ]
+                }
+              ],
+              "relativeUri": "/projects",
+              "displayName": "/projects",
+              "relativeUriPathSegments": [
+                "projects"
+              ],
+              "absoluteUri": "https://api.semaphoreci.com/v2/orgs/{org_username}/projects",
+              "parentUrl": "/orgs/{org_username}",
+              "uniqueId": "orgs__org_username__projects",
+              "allUriParameters": [
+                {
+                  "name": "org_username",
+                  "displayName": "org_username",
+                  "typePropertyKind": "TYPE_EXPRESSION",
+                  "type": "string",
+                  "required": true,
+                  "key": "org_username"
+                }
+              ]
+            },
+            {
+              "methods": [
+                {
+                  "responses": [
+                    {
+                      "code": "200",
+                      "body": [
+                        {
+                          "name": "application/json",
+                          "displayName": "application/json",
+                          "typePropertyKind": "TYPE_EXPRESSION",
+                          "type": "array",
+                          "items": {
+                            "additionalProperties": true,
+                            "displayName": "SharedConfig",
+                            "type": "object",
+                            "name": "SharedConfig",
+                            "typePropertyKind": "TYPE_EXPRESSION",
+                            "properties": [
+                              {
+                                "displayName": "name",
+                                "type": "string",
+                                "example": "AWS Tokens",
+                                "required": true,
+                                "key": "name"
+                              },
+                              {
+                                "displayName": "description",
+                                "type": "string",
+                                "example": "AWS tokens for deployment",
+                                "required": false,
+                                "key": "description"
+                              },
+                              {
+                                "displayName": "id",
+                                "type": "string",
+                                "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
+                                "name": "id",
+                                "typePropertyKind": "TYPE_EXPRESSION",
+                                "required": true,
+                                "examples": [
+                                  {
+                                    "value": "86e78b7e-2f9c-45a7-9939-ec2c9f6f64b5",
+                                    "strict": true,
+                                    "structuredValue": "86e78b7e-2f9c-45a7-9939-ec2c9f6f64b5"
+                                  }
+                                ],
+                                "key": "id"
+                              },
+                              {
+                                "type": "string",
+                                "displayName": "url",
+                                "name": "url",
+                                "typePropertyKind": "TYPE_EXPRESSION",
+                                "required": true,
+                                "examples": [
+                                  {
+                                    "value": "https://api.semaphoreci.com/v2/shared_configs/86e78b7e-2f9c-45a7-9939-ec2c9f6f64b5",
+                                    "strict": true,
+                                    "structuredValue": "https://api.semaphoreci.com/v2/shared_configs/86e78b7e-2f9c-45a7-9939-ec2c9f6f64b5"
+                                  }
+                                ],
+                                "key": "url"
+                              },
+                              {
+                                "format": "rfc3339",
+                                "displayName": "created_at",
+                                "type": "datetime",
+                                "name": "created_at",
+                                "typePropertyKind": "TYPE_EXPRESSION",
+                                "required": true,
+                                "key": "created_at"
+                              },
+                              {
+                                "format": "rfc3339",
+                                "displayName": "updated_at",
+                                "type": "datetime",
+                                "name": "updated_at",
+                                "typePropertyKind": "TYPE_EXPRESSION",
+                                "required": true,
+                                "key": "updated_at"
+                              }
+                            ]
+                          },
+                          "key": "application/json"
+                        }
+                      ],
+                      "key": "200"
+                    }
+                  ],
+                  "protocols": [
+                    "HTTPS"
+                  ],
+                  "is": [
+                    {
+                      "withResponseItems": {
+                        "item": "SharedConfig"
+                      }
+                    }
+                  ],
+                  "displayName": "List shared configurations in an organization",
+                  "method": "get",
+                  "allUriParameters": [
+                    {
+                      "name": "org_username",
+                      "displayName": "org_username",
+                      "typePropertyKind": "TYPE_EXPRESSION",
+                      "type": "string",
+                      "required": true,
+                      "key": "org_username"
+                    }
+                  ]
+                },
+                {
+                  "responses": [
+                    {
+                      "code": "200",
+                      "body": [
+                        {
+                          "name": "SharedConfig",
+                          "displayName": "SharedConfig",
+                          "typePropertyKind": "TYPE_EXPRESSION",
+                          "type": "object",
+                          "additionalProperties": true,
+                          "properties": [
+                            {
+                              "displayName": "name",
+                              "type": "string",
+                              "example": "AWS Tokens",
+                              "required": true,
+                              "key": "name"
+                            },
+                            {
+                              "displayName": "description",
+                              "type": "string",
+                              "example": "AWS tokens for deployment",
+                              "required": false,
+                              "key": "description"
+                            },
+                            {
+                              "displayName": "id",
+                              "type": "string",
+                              "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
+                              "name": "id",
+                              "typePropertyKind": "TYPE_EXPRESSION",
+                              "required": true,
+                              "examples": [
+                                {
+                                  "value": "86e78b7e-2f9c-45a7-9939-ec2c9f6f64b5",
+                                  "strict": true,
+                                  "structuredValue": "86e78b7e-2f9c-45a7-9939-ec2c9f6f64b5"
+                                }
+                              ],
+                              "key": "id"
+                            },
+                            {
+                              "type": "string",
+                              "displayName": "url",
+                              "name": "url",
+                              "typePropertyKind": "TYPE_EXPRESSION",
+                              "required": true,
+                              "examples": [
+                                {
+                                  "value": "https://api.semaphoreci.com/v2/shared_configs/86e78b7e-2f9c-45a7-9939-ec2c9f6f64b5",
+                                  "strict": true,
+                                  "structuredValue": "https://api.semaphoreci.com/v2/shared_configs/86e78b7e-2f9c-45a7-9939-ec2c9f6f64b5"
+                                }
+                              ],
+                              "key": "url"
+                            },
+                            {
+                              "format": "rfc3339",
+                              "displayName": "created_at",
+                              "type": "datetime",
+                              "name": "created_at",
+                              "typePropertyKind": "TYPE_EXPRESSION",
+                              "required": true,
+                              "key": "created_at"
+                            },
+                            {
+                              "format": "rfc3339",
+                              "displayName": "updated_at",
+                              "type": "datetime",
+                              "name": "updated_at",
+                              "typePropertyKind": "TYPE_EXPRESSION",
+                              "required": true,
+                              "key": "updated_at"
+                            }
+                          ],
+                          "key": "application/json"
+                        }
+                      ],
+                      "key": "200"
+                    },
+                    {
+                      "code": "404",
+                      "body": [
+                        {
+                          "name": "Error",
+                          "displayName": "Error",
+                          "typePropertyKind": "TYPE_EXPRESSION",
+                          "type": "object",
+                          "additionalProperties": true,
+                          "properties": [
+                            {
+                              "type": "string",
+                              "displayName": "message",
+                              "name": "message",
+                              "typePropertyKind": "TYPE_EXPRESSION",
+                              "required": true,
+                              "key": "message"
+                            }
+                          ],
+                          "key": "application/json"
+                        }
+                      ],
+                      "key": "404"
+                    },
+                    {
+                      "code": "412",
+                      "body": [
+                        {
+                          "name": "Error",
+                          "displayName": "Error",
+                          "typePropertyKind": "TYPE_EXPRESSION",
+                          "type": "object",
+                          "additionalProperties": true,
+                          "properties": [
+                            {
+                              "type": "string",
+                              "displayName": "message",
+                              "name": "message",
+                              "typePropertyKind": "TYPE_EXPRESSION",
+                              "required": true,
+                              "key": "message"
+                            }
+                          ],
+                          "key": "application/json"
+                        }
+                      ],
+                      "key": "412"
+                    }
+                  ],
+                  "body": [
+                    {
+                      "name": "SharedConfigPost",
+                      "displayName": "SharedConfigPost",
+                      "typePropertyKind": "TYPE_EXPRESSION",
+                      "type": "object",
+                      "additionalProperties": true,
+                      "properties": [
+                        {
+                          "type": "string",
+                          "displayName": "name",
+                          "name": "name",
+                          "typePropertyKind": "TYPE_EXPRESSION",
+                          "required": true,
+                          "examples": [
+                            {
+                              "value": "AWS Tokens",
+                              "strict": true,
+                              "structuredValue": "AWS Tokens"
+                            }
+                          ],
+                          "key": "name"
+                        },
+                        {
+                          "type": "string",
+                          "displayName": "description",
+                          "name": "description",
+                          "typePropertyKind": "TYPE_EXPRESSION",
+                          "required": false,
+                          "examples": [
+                            {
+                              "value": "AWS tokens for deployment",
+                              "strict": true,
+                              "structuredValue": "AWS tokens for deployment"
+                            }
+                          ],
+                          "key": "description"
+                        }
+                      ],
+                      "key": "application/json"
+                    }
+                  ],
+                  "protocols": [
+                    "HTTPS"
+                  ],
+                  "is": [
+                    {
+                      "withRequestItem": {
+                        "item": "SharedConfigPost"
+                      }
+                    },
+                    {
+                      "withResponseItem": {
+                        "item": "SharedConfig"
+                      }
+                    },
+                    "withNotFoundError",
+                    "withPreconditionFailedError"
+                  ],
+                  "displayName": "Create shared configuration in an organization",
+                  "method": "post",
+                  "allUriParameters": [
+                    {
+                      "name": "org_username",
+                      "displayName": "org_username",
+                      "typePropertyKind": "TYPE_EXPRESSION",
+                      "type": "string",
+                      "required": true,
+                      "key": "org_username"
+                    }
+                  ]
+                }
+              ],
+              "relativeUri": "/shared_configs",
+              "displayName": "/shared_configs",
+              "relativeUriPathSegments": [
+                "shared_configs"
+              ],
+              "absoluteUri": "https://api.semaphoreci.com/v2/orgs/{org_username}/shared_configs",
+              "parentUrl": "/orgs/{org_username}",
+              "uniqueId": "orgs__org_username__shared_configs",
+              "allUriParameters": [
+                {
+                  "name": "org_username",
+                  "displayName": "org_username",
+                  "typePropertyKind": "TYPE_EXPRESSION",
+                  "type": "string",
+                  "required": true,
+                  "key": "org_username"
+                }
+              ]
+            },
+            {
+              "methods": [
+                {
+                  "responses": [
+                    {
+                      "code": "200",
+                      "body": [
+                        {
+                          "name": "application/json",
+                          "displayName": "application/json",
+                          "typePropertyKind": "TYPE_EXPRESSION",
+                          "type": "array",
+                          "items": {
+                            "additionalProperties": true,
+                            "type": "object",
+                            "displayName": "User",
+                            "name": "User",
+                            "typePropertyKind": "TYPE_EXPRESSION",
+                            "properties": [
+                              {
+                                "displayName": "uid",
+                                "type": "string",
+                                "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
+                                "name": "uid",
+                                "typePropertyKind": "TYPE_EXPRESSION",
+                                "required": true,
+                                "examples": [
+                                  {
+                                    "value": "86e78b7e-2f9c-45a7-9939-ec2c9f6f64b5",
+                                    "strict": true,
+                                    "structuredValue": "86e78b7e-2f9c-45a7-9939-ec2c9f6f64b5"
+                                  }
+                                ],
+                                "key": "uid"
+                              },
+                              {
+                                "type": "string",
+                                "displayName": "username",
+                                "name": "username",
+                                "typePropertyKind": "TYPE_EXPRESSION",
+                                "required": true,
+                                "examples": [
+                                  {
+                                    "value": "johndoe",
+                                    "strict": true,
+                                    "structuredValue": "johndoe"
+                                  }
+                                ],
+                                "key": "username"
+                              },
+                              {
+                                "type": "string",
+                                "displayName": "name",
+                                "name": "name",
+                                "typePropertyKind": "TYPE_EXPRESSION",
+                                "required": true,
+                                "examples": [
+                                  {
+                                    "value": "John Doe",
+                                    "strict": true,
+                                    "structuredValue": "John Doe"
+                                  }
+                                ],
+                                "key": "name"
+                              },
+                              {
+                                "format": "rfc3339",
+                                "displayName": "created_at",
+                                "type": "datetime",
+                                "name": "created_at",
+                                "typePropertyKind": "TYPE_EXPRESSION",
+                                "required": true,
+                                "key": "created_at"
+                              },
+                              {
+                                "format": "rfc3339",
+                                "displayName": "updated_at",
+                                "type": "datetime",
+                                "name": "updated_at",
+                                "typePropertyKind": "TYPE_EXPRESSION",
+                                "required": true,
+                                "key": "updated_at"
+                              }
+                            ]
+                          },
+                          "key": "application/json"
+                        }
+                      ],
+                      "key": "200"
+                    },
+                    {
+                      "code": "404",
+                      "body": [
+                        {
+                          "name": "Error",
+                          "displayName": "Error",
+                          "typePropertyKind": "TYPE_EXPRESSION",
+                          "type": "object",
+                          "additionalProperties": true,
+                          "properties": [
+                            {
+                              "type": "string",
+                              "displayName": "message",
+                              "name": "message",
+                              "typePropertyKind": "TYPE_EXPRESSION",
+                              "required": true,
+                              "key": "message"
+                            }
+                          ],
+                          "key": "application/json"
+                        }
+                      ],
+                      "key": "404"
+                    }
+                  ],
+                  "protocols": [
+                    "HTTPS"
+                  ],
+                  "is": [
+                    {
+                      "withResponseItems": {
+                        "item": "User"
+                      }
+                    },
+                    "withNotFoundError"
+                  ],
+                  "displayName": "List all users for a organization",
+                  "method": "get",
+                  "allUriParameters": [
+                    {
+                      "name": "org_username",
+                      "displayName": "org_username",
+                      "typePropertyKind": "TYPE_EXPRESSION",
+                      "type": "string",
+                      "required": true,
+                      "key": "org_username"
+                    }
+                  ]
+                }
+              ],
+              "relativeUri": "/users",
+              "displayName": "/users",
+              "relativeUriPathSegments": [
+                "users"
+              ],
+              "absoluteUri": "https://api.semaphoreci.com/v2/orgs/{org_username}/users",
+              "parentUrl": "/orgs/{org_username}",
+              "uniqueId": "orgs__org_username__users",
+              "allUriParameters": [
+                {
+                  "name": "org_username",
+                  "displayName": "org_username",
+                  "typePropertyKind": "TYPE_EXPRESSION",
+                  "type": "string",
+                  "required": true,
+                  "key": "org_username"
+                }
+              ]
+            }
+          ],
+          "relativeUriPathSegments": [
+            "{org_username}"
+          ],
+          "absoluteUri": "https://api.semaphoreci.com/v2/orgs/{org_username}",
+          "parentUrl": "/orgs",
+          "uniqueId": "orgs__org_username_",
+          "allUriParameters": [
+            {
+              "name": "org_username",
+              "displayName": "org_username",
+              "typePropertyKind": "TYPE_EXPRESSION",
+              "type": "string",
+              "required": true,
+              "key": "org_username"
+            }
+          ]
+        }
+      ],
+      "relativeUriPathSegments": [
+        "orgs"
+      ],
+      "absoluteUri": "https://api.semaphoreci.com/v2/orgs",
+      "parentUrl": "",
+      "uniqueId": "orgs",
+      "allUriParameters": []
+    },
+    {
+      "relativeUri": "/teams",
+      "displayName": "Teams",
+      "resources": [
+        {
+          "methods": [
+            {
+              "responses": [
+                {
+                  "code": "200",
+                  "body": [
+                    {
+                      "name": "Team",
+                      "displayName": "Team",
+                      "typePropertyKind": "TYPE_EXPRESSION",
+                      "type": "object",
+                      "additionalProperties": true,
+                      "properties": [
+                        {
+                          "displayName": "name",
+                          "type": "string",
+                          "example": "developers",
+                          "required": true,
+                          "key": "name"
+                        },
+                        {
+                          "enum": [
+                            "read",
+                            "write",
+                            "admin"
+                          ],
+                          "displayName": "permission",
+                          "type": "string",
+                          "example": "write",
+                          "required": true,
+                          "key": "permission"
+                        },
+                        {
+                          "displayName": "description",
+                          "type": "string",
+                          "example": "Developers team",
+                          "required": false,
+                          "key": "description"
+                        },
+                        {
+                          "displayName": "id",
+                          "type": "string",
+                          "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
+                          "name": "id",
+                          "typePropertyKind": "TYPE_EXPRESSION",
+                          "required": true,
+                          "examples": [
+                            {
+                              "value": "86e78b7e-2f9c-45a7-9939-ec2c9f6f64b5",
+                              "strict": true,
+                              "structuredValue": "86e78b7e-2f9c-45a7-9939-ec2c9f6f64b5"
+                            }
+                          ],
+                          "key": "id"
+                        },
+                        {
+                          "type": "string",
+                          "displayName": "url",
+                          "name": "url",
+                          "typePropertyKind": "TYPE_EXPRESSION",
+                          "required": true,
+                          "examples": [
+                            {
+                              "value": "https://api.semaphoreci.com/v2/teams/86e78b7e-2f9c-45a7-9939-ec2c9f6f64b5",
+                              "strict": true,
+                              "structuredValue": "https://api.semaphoreci.com/v2/teams/86e78b7e-2f9c-45a7-9939-ec2c9f6f64b5"
+                            }
+                          ],
+                          "key": "url"
+                        },
+                        {
+                          "format": "rfc3339",
+                          "displayName": "updated_at",
+                          "type": "datetime",
+                          "name": "updated_at",
+                          "typePropertyKind": "TYPE_EXPRESSION",
+                          "required": true,
+                          "key": "updated_at"
+                        },
+                        {
+                          "format": "rfc3339",
+                          "displayName": "created_at",
+                          "type": "datetime",
+                          "name": "created_at",
+                          "typePropertyKind": "TYPE_EXPRESSION",
+                          "required": true,
+                          "key": "created_at"
+                        }
+                      ],
+                      "key": "application/json"
+                    }
+                  ],
+                  "key": "200"
+                },
+                {
+                  "code": "404",
+                  "body": [
+                    {
+                      "name": "Error",
+                      "displayName": "Error",
+                      "typePropertyKind": "TYPE_EXPRESSION",
+                      "type": "object",
+                      "additionalProperties": true,
+                      "properties": [
+                        {
+                          "type": "string",
+                          "displayName": "message",
+                          "name": "message",
+                          "typePropertyKind": "TYPE_EXPRESSION",
+                          "required": true,
+                          "key": "message"
+                        }
+                      ],
+                      "key": "application/json"
+                    }
+                  ],
+                  "key": "404"
+                }
+              ],
+              "protocols": [
+                "HTTPS"
+              ],
+              "is": [
+                {
+                  "withResponseItem": {
+                    "item": "Team"
+                  }
+                },
+                "withNotFoundError"
+              ],
+              "displayName": "Get a team",
+              "method": "get",
+              "allUriParameters": [
+                {
+                  "name": "id",
+                  "displayName": "id",
+                  "typePropertyKind": "TYPE_EXPRESSION",
+                  "type": "string",
+                  "required": true,
+                  "key": "id"
+                }
+              ]
+            },
+            {
+              "responses": [
+                {
+                  "code": "204",
+                  "key": "204"
+                },
+                {
+                  "code": "404",
+                  "body": [
+                    {
+                      "name": "Error",
+                      "displayName": "Error",
+                      "typePropertyKind": "TYPE_EXPRESSION",
+                      "type": "object",
+                      "additionalProperties": true,
+                      "properties": [
+                        {
+                          "type": "string",
+                          "displayName": "message",
+                          "name": "message",
+                          "typePropertyKind": "TYPE_EXPRESSION",
+                          "required": true,
+                          "key": "message"
+                        }
+                      ],
+                      "key": "application/json"
+                    }
+                  ],
+                  "key": "404"
+                }
+              ],
+              "protocols": [
+                "HTTPS"
+              ],
+              "is": [
+                "withNoBodyResponse",
+                "withNotFoundError"
+              ],
+              "displayName": "Delete a team",
+              "method": "delete",
+              "allUriParameters": [
+                {
+                  "name": "id",
+                  "displayName": "id",
+                  "typePropertyKind": "TYPE_EXPRESSION",
+                  "type": "string",
+                  "required": true,
+                  "key": "id"
+                }
+              ]
+            },
+            {
+              "responses": [
+                {
+                  "code": "200",
+                  "body": [
+                    {
+                      "name": "Team",
+                      "displayName": "Team",
+                      "typePropertyKind": "TYPE_EXPRESSION",
+                      "type": "object",
+                      "additionalProperties": true,
+                      "properties": [
+                        {
+                          "displayName": "name",
+                          "type": "string",
+                          "example": "developers",
+                          "required": true,
+                          "key": "name"
+                        },
+                        {
+                          "enum": [
+                            "read",
+                            "write",
+                            "admin"
+                          ],
+                          "displayName": "permission",
+                          "type": "string",
+                          "example": "write",
+                          "required": true,
+                          "key": "permission"
+                        },
+                        {
+                          "displayName": "description",
+                          "type": "string",
+                          "example": "Developers team",
+                          "required": false,
+                          "key": "description"
+                        },
+                        {
+                          "displayName": "id",
+                          "type": "string",
+                          "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
+                          "name": "id",
+                          "typePropertyKind": "TYPE_EXPRESSION",
+                          "required": true,
+                          "examples": [
+                            {
+                              "value": "86e78b7e-2f9c-45a7-9939-ec2c9f6f64b5",
+                              "strict": true,
+                              "structuredValue": "86e78b7e-2f9c-45a7-9939-ec2c9f6f64b5"
+                            }
+                          ],
+                          "key": "id"
+                        },
+                        {
+                          "type": "string",
+                          "displayName": "url",
+                          "name": "url",
+                          "typePropertyKind": "TYPE_EXPRESSION",
+                          "required": true,
+                          "examples": [
+                            {
+                              "value": "https://api.semaphoreci.com/v2/teams/86e78b7e-2f9c-45a7-9939-ec2c9f6f64b5",
+                              "strict": true,
+                              "structuredValue": "https://api.semaphoreci.com/v2/teams/86e78b7e-2f9c-45a7-9939-ec2c9f6f64b5"
+                            }
+                          ],
+                          "key": "url"
+                        },
+                        {
+                          "format": "rfc3339",
+                          "displayName": "updated_at",
+                          "type": "datetime",
+                          "name": "updated_at",
+                          "typePropertyKind": "TYPE_EXPRESSION",
+                          "required": true,
+                          "key": "updated_at"
+                        },
+                        {
+                          "format": "rfc3339",
+                          "displayName": "created_at",
+                          "type": "datetime",
+                          "name": "created_at",
+                          "typePropertyKind": "TYPE_EXPRESSION",
+                          "required": true,
+                          "key": "created_at"
+                        }
+                      ],
+                      "key": "application/json"
+                    }
+                  ],
+                  "key": "200"
+                },
+                {
+                  "code": "404",
+                  "body": [
+                    {
+                      "name": "Error",
+                      "displayName": "Error",
+                      "typePropertyKind": "TYPE_EXPRESSION",
+                      "type": "object",
+                      "additionalProperties": true,
+                      "properties": [
+                        {
+                          "type": "string",
+                          "displayName": "message",
+                          "name": "message",
+                          "typePropertyKind": "TYPE_EXPRESSION",
+                          "required": true,
+                          "key": "message"
+                        }
+                      ],
+                      "key": "application/json"
+                    }
+                  ],
+                  "key": "404"
+                }
+              ],
+              "body": [
+                {
+                  "name": "TeamPatch",
+                  "displayName": "TeamPatch",
+                  "typePropertyKind": "TYPE_EXPRESSION",
+                  "type": "object",
+                  "additionalProperties": true,
+                  "properties": [
+                    {
+                      "type": "string",
+                      "displayName": "name",
+                      "name": "name",
+                      "typePropertyKind": "TYPE_EXPRESSION",
+                      "required": false,
+                      "examples": [
+                        {
+                          "value": "developers",
+                          "strict": true,
+                          "structuredValue": "developers"
+                        }
+                      ],
+                      "key": "name"
+                    },
+                    {
+                      "type": "string",
+                      "enum": [
+                        "read",
+                        "write",
+                        "admin"
+                      ],
+                      "displayName": "permission",
+                      "name": "permission",
+                      "typePropertyKind": "TYPE_EXPRESSION",
+                      "required": false,
+                      "examples": [
+                        {
+                          "value": "write",
+                          "strict": true,
+                          "structuredValue": "write"
+                        }
+                      ],
+                      "key": "permission"
+                    },
+                    {
+                      "type": "string",
+                      "displayName": "description",
+                      "name": "description",
+                      "typePropertyKind": "TYPE_EXPRESSION",
+                      "required": false,
+                      "examples": [
+                        {
+                          "value": "Developers team",
+                          "strict": true,
+                          "structuredValue": "Developers team"
+                        }
+                      ],
+                      "key": "description"
+                    }
+                  ],
+                  "key": "application/json"
+                }
+              ],
+              "protocols": [
+                "HTTPS"
+              ],
+              "is": [
+                {
+                  "withRequestItem": {
+                    "item": "TeamPatch"
+                  }
+                },
+                {
+                  "withResponseItem": {
+                    "item": "Team"
+                  }
+                },
+                "withNotFoundError"
+              ],
+              "displayName": "Update a team",
+              "method": "patch",
+              "allUriParameters": [
+                {
+                  "name": "id",
+                  "displayName": "id",
+                  "typePropertyKind": "TYPE_EXPRESSION",
+                  "type": "string",
+                  "required": true,
+                  "key": "id"
+                }
+              ]
+            }
+          ],
+          "uriParameters": [
+            {
+              "name": "id",
+              "displayName": "id",
+              "typePropertyKind": "TYPE_EXPRESSION",
+              "type": "string",
+              "required": true,
+              "key": "id"
+            }
+          ],
+          "relativeUri": "/{id}",
+          "displayName": "/{id}",
+          "relativeUriPathSegments": [
+            "{id}"
+          ],
+          "absoluteUri": "https://api.semaphoreci.com/v2/teams/{id}",
+          "parentUrl": "/teams",
+          "uniqueId": "teams__id_",
+          "allUriParameters": [
+            {
+              "name": "id",
+              "displayName": "id",
+              "typePropertyKind": "TYPE_EXPRESSION",
+              "type": "string",
+              "required": true,
+              "key": "id"
+            }
+          ]
+        },
+        {
+          "uriParameters": [
+            {
+              "name": "team_id",
+              "displayName": "team_id",
+              "typePropertyKind": "TYPE_EXPRESSION",
+              "type": "string",
+              "required": true,
+              "key": "team_id"
+            }
+          ],
+          "relativeUri": "/{team_id}",
+          "displayName": "/{team_id}",
+          "resources": [
+            {
+              "methods": [
+                {
+                  "responses": [
+                    {
+                      "code": "200",
+                      "body": [
+                        {
+                          "name": "application/json",
+                          "displayName": "application/json",
+                          "typePropertyKind": "TYPE_EXPRESSION",
+                          "type": "array",
+                          "items": {
+                            "additionalProperties": true,
+                            "displayName": "SharedConfig",
+                            "type": "object",
+                            "name": "SharedConfig",
+                            "typePropertyKind": "TYPE_EXPRESSION",
+                            "properties": [
+                              {
+                                "displayName": "name",
+                                "type": "string",
+                                "example": "AWS Tokens",
+                                "required": true,
+                                "key": "name"
+                              },
+                              {
+                                "displayName": "description",
+                                "type": "string",
+                                "example": "AWS tokens for deployment",
+                                "required": false,
+                                "key": "description"
+                              },
+                              {
+                                "displayName": "id",
+                                "type": "string",
+                                "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
+                                "name": "id",
+                                "typePropertyKind": "TYPE_EXPRESSION",
+                                "required": true,
+                                "examples": [
+                                  {
+                                    "value": "86e78b7e-2f9c-45a7-9939-ec2c9f6f64b5",
+                                    "strict": true,
+                                    "structuredValue": "86e78b7e-2f9c-45a7-9939-ec2c9f6f64b5"
+                                  }
+                                ],
+                                "key": "id"
+                              },
+                              {
+                                "type": "string",
+                                "displayName": "url",
+                                "name": "url",
+                                "typePropertyKind": "TYPE_EXPRESSION",
+                                "required": true,
+                                "examples": [
+                                  {
+                                    "value": "https://api.semaphoreci.com/v2/shared_configs/86e78b7e-2f9c-45a7-9939-ec2c9f6f64b5",
+                                    "strict": true,
+                                    "structuredValue": "https://api.semaphoreci.com/v2/shared_configs/86e78b7e-2f9c-45a7-9939-ec2c9f6f64b5"
+                                  }
+                                ],
+                                "key": "url"
+                              },
+                              {
+                                "format": "rfc3339",
+                                "displayName": "created_at",
+                                "type": "datetime",
+                                "name": "created_at",
+                                "typePropertyKind": "TYPE_EXPRESSION",
+                                "required": true,
+                                "key": "created_at"
+                              },
+                              {
+                                "format": "rfc3339",
+                                "displayName": "updated_at",
+                                "type": "datetime",
+                                "name": "updated_at",
+                                "typePropertyKind": "TYPE_EXPRESSION",
+                                "required": true,
+                                "key": "updated_at"
+                              }
+                            ]
+                          },
+                          "key": "application/json"
+                        }
+                      ],
+                      "key": "200"
+                    },
+                    {
+                      "code": "404",
+                      "body": [
+                        {
+                          "name": "Error",
+                          "displayName": "Error",
+                          "typePropertyKind": "TYPE_EXPRESSION",
+                          "type": "object",
+                          "additionalProperties": true,
+                          "properties": [
+                            {
+                              "type": "string",
+                              "displayName": "message",
+                              "name": "message",
+                              "typePropertyKind": "TYPE_EXPRESSION",
+                              "required": true,
+                              "key": "message"
+                            }
+                          ],
+                          "key": "application/json"
+                        }
+                      ],
+                      "key": "404"
+                    }
+                  ],
+                  "protocols": [
+                    "HTTPS"
+                  ],
+                  "is": [
+                    {
+                      "withResponseItems": {
+                        "item": "SharedConfig"
+                      }
+                    },
+                    "withNotFoundError"
+                  ],
+                  "displayName": "List shared configurations in a team",
+                  "method": "get",
+                  "allUriParameters": [
+                    {
+                      "name": "team_id",
+                      "displayName": "team_id",
+                      "typePropertyKind": "TYPE_EXPRESSION",
+                      "type": "string",
+                      "required": true,
+                      "key": "team_id"
+                    }
+                  ]
+                }
+              ],
+              "relativeUri": "/shared_configs",
+              "displayName": "/shared_configs",
+              "resources": [
+                {
+                  "methods": [
+                    {
+                      "responses": [
+                        {
+                          "code": "204",
+                          "key": "204"
+                        },
+                        {
+                          "code": "404",
+                          "body": [
+                            {
+                              "name": "Error",
+                              "displayName": "Error",
+                              "typePropertyKind": "TYPE_EXPRESSION",
+                              "type": "object",
+                              "additionalProperties": true,
+                              "properties": [
+                                {
+                                  "type": "string",
+                                  "displayName": "message",
+                                  "name": "message",
+                                  "typePropertyKind": "TYPE_EXPRESSION",
+                                  "required": true,
+                                  "key": "message"
+                                }
+                              ],
+                              "key": "application/json"
+                            }
+                          ],
+                          "key": "404"
+                        }
+                      ],
+                      "protocols": [
+                        "HTTPS"
+                      ],
+                      "is": [
+                        "withNoBodyResponse",
+                        "withNotFoundError"
+                      ],
+                      "displayName": "Add a shared configuration to a team",
+                      "method": "post",
+                      "allUriParameters": [
+                        {
+                          "name": "team_id",
+                          "displayName": "team_id",
+                          "typePropertyKind": "TYPE_EXPRESSION",
+                          "type": "string",
+                          "required": true,
+                          "key": "team_id"
+                        },
+                        {
+                          "name": "shared_config_id",
+                          "displayName": "shared_config_id",
+                          "typePropertyKind": "TYPE_EXPRESSION",
+                          "type": "string",
+                          "required": true,
+                          "key": "shared_config_id"
+                        }
+                      ]
+                    },
+                    {
+                      "responses": [
+                        {
+                          "code": "204",
+                          "key": "204"
+                        },
+                        {
+                          "code": "404",
+                          "body": [
+                            {
+                              "name": "Error",
+                              "displayName": "Error",
+                              "typePropertyKind": "TYPE_EXPRESSION",
+                              "type": "object",
+                              "additionalProperties": true,
+                              "properties": [
+                                {
+                                  "type": "string",
+                                  "displayName": "message",
+                                  "name": "message",
+                                  "typePropertyKind": "TYPE_EXPRESSION",
+                                  "required": true,
+                                  "key": "message"
+                                }
+                              ],
+                              "key": "application/json"
+                            }
+                          ],
+                          "key": "404"
+                        }
+                      ],
+                      "protocols": [
+                        "HTTPS"
+                      ],
+                      "is": [
+                        "withNoBodyResponse",
+                        "withNotFoundError"
+                      ],
+                      "displayName": "Remove shared configuration from a team",
+                      "method": "delete",
+                      "allUriParameters": [
+                        {
+                          "name": "team_id",
+                          "displayName": "team_id",
+                          "typePropertyKind": "TYPE_EXPRESSION",
+                          "type": "string",
+                          "required": true,
+                          "key": "team_id"
+                        },
+                        {
+                          "name": "shared_config_id",
+                          "displayName": "shared_config_id",
+                          "typePropertyKind": "TYPE_EXPRESSION",
+                          "type": "string",
+                          "required": true,
+                          "key": "shared_config_id"
+                        }
+                      ]
+                    }
+                  ],
+                  "uriParameters": [
+                    {
+                      "name": "shared_config_id",
+                      "displayName": "shared_config_id",
+                      "typePropertyKind": "TYPE_EXPRESSION",
+                      "type": "string",
+                      "required": true,
+                      "key": "shared_config_id"
+                    }
+                  ],
+                  "relativeUri": "/{shared_config_id}",
+                  "displayName": "/{shared_config_id}",
+                  "relativeUriPathSegments": [
+                    "{shared_config_id}"
+                  ],
+                  "absoluteUri": "https://api.semaphoreci.com/v2/teams/{team_id}/shared_configs/{shared_config_id}",
+                  "parentUrl": "/teams/{team_id}/shared_configs",
+                  "uniqueId": "teams__team_id__shared_configs__shared_config_id_",
+                  "allUriParameters": [
+                    {
+                      "name": "team_id",
+                      "displayName": "team_id",
+                      "typePropertyKind": "TYPE_EXPRESSION",
+                      "type": "string",
+                      "required": true,
+                      "key": "team_id"
+                    },
+                    {
+                      "name": "shared_config_id",
+                      "displayName": "shared_config_id",
+                      "typePropertyKind": "TYPE_EXPRESSION",
+                      "type": "string",
+                      "required": true,
+                      "key": "shared_config_id"
+                    }
+                  ]
+                }
+              ],
+              "relativeUriPathSegments": [
+                "shared_configs"
+              ],
+              "absoluteUri": "https://api.semaphoreci.com/v2/teams/{team_id}/shared_configs",
+              "parentUrl": "/teams/{team_id}",
+              "uniqueId": "teams__team_id__shared_configs",
+              "allUriParameters": [
+                {
+                  "name": "team_id",
+                  "displayName": "team_id",
+                  "typePropertyKind": "TYPE_EXPRESSION",
+                  "type": "string",
+                  "required": true,
+                  "key": "team_id"
+                }
+              ]
+            },
+            {
+              "methods": [
+                {
+                  "responses": [
+                    {
+                      "code": "200",
+                      "body": [
+                        {
+                          "name": "application/json",
+                          "displayName": "application/json",
+                          "typePropertyKind": "TYPE_EXPRESSION",
+                          "type": "array",
+                          "items": {
+                            "additionalProperties": true,
+                            "type": "object",
+                            "displayName": "User",
+                            "name": "User",
+                            "typePropertyKind": "TYPE_EXPRESSION",
+                            "properties": [
+                              {
+                                "displayName": "uid",
+                                "type": "string",
+                                "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
+                                "name": "uid",
+                                "typePropertyKind": "TYPE_EXPRESSION",
+                                "required": true,
+                                "examples": [
+                                  {
+                                    "value": "86e78b7e-2f9c-45a7-9939-ec2c9f6f64b5",
+                                    "strict": true,
+                                    "structuredValue": "86e78b7e-2f9c-45a7-9939-ec2c9f6f64b5"
+                                  }
+                                ],
+                                "key": "uid"
+                              },
+                              {
+                                "type": "string",
+                                "displayName": "username",
+                                "name": "username",
+                                "typePropertyKind": "TYPE_EXPRESSION",
+                                "required": true,
+                                "examples": [
+                                  {
+                                    "value": "johndoe",
+                                    "strict": true,
+                                    "structuredValue": "johndoe"
+                                  }
+                                ],
+                                "key": "username"
+                              },
+                              {
+                                "type": "string",
+                                "displayName": "name",
+                                "name": "name",
+                                "typePropertyKind": "TYPE_EXPRESSION",
+                                "required": true,
+                                "examples": [
+                                  {
+                                    "value": "John Doe",
+                                    "strict": true,
+                                    "structuredValue": "John Doe"
+                                  }
+                                ],
+                                "key": "name"
+                              },
+                              {
+                                "format": "rfc3339",
+                                "displayName": "created_at",
+                                "type": "datetime",
+                                "name": "created_at",
+                                "typePropertyKind": "TYPE_EXPRESSION",
+                                "required": true,
+                                "key": "created_at"
+                              },
+                              {
+                                "format": "rfc3339",
+                                "displayName": "updated_at",
+                                "type": "datetime",
+                                "name": "updated_at",
+                                "typePropertyKind": "TYPE_EXPRESSION",
+                                "required": true,
+                                "key": "updated_at"
+                              }
+                            ]
+                          },
+                          "key": "application/json"
+                        }
+                      ],
+                      "key": "200"
+                    },
+                    {
+                      "code": "404",
+                      "body": [
+                        {
+                          "name": "Error",
+                          "displayName": "Error",
+                          "typePropertyKind": "TYPE_EXPRESSION",
+                          "type": "object",
+                          "additionalProperties": true,
+                          "properties": [
+                            {
+                              "type": "string",
+                              "displayName": "message",
+                              "name": "message",
+                              "typePropertyKind": "TYPE_EXPRESSION",
+                              "required": true,
+                              "key": "message"
+                            }
+                          ],
+                          "key": "application/json"
+                        }
+                      ],
+                      "key": "404"
+                    }
+                  ],
+                  "protocols": [
+                    "HTTPS"
+                  ],
+                  "is": [
+                    {
+                      "withResponseItems": {
+                        "item": "User"
+                      }
+                    },
+                    "withNotFoundError"
+                  ],
+                  "displayName": "List members of a team",
+                  "method": "get",
+                  "allUriParameters": [
+                    {
+                      "name": "team_id",
+                      "displayName": "team_id",
+                      "typePropertyKind": "TYPE_EXPRESSION",
+                      "type": "string",
+                      "required": true,
+                      "key": "team_id"
+                    }
+                  ]
+                }
+              ],
+              "relativeUri": "/users",
+              "displayName": "/users",
+              "resources": [
+                {
+                  "methods": [
+                    {
+                      "responses": [
+                        {
+                          "code": "204",
+                          "key": "204"
+                        },
+                        {
+                          "code": "404",
+                          "body": [
+                            {
+                              "name": "Error",
+                              "displayName": "Error",
+                              "typePropertyKind": "TYPE_EXPRESSION",
+                              "type": "object",
+                              "additionalProperties": true,
+                              "properties": [
+                                {
+                                  "type": "string",
+                                  "displayName": "message",
+                                  "name": "message",
+                                  "typePropertyKind": "TYPE_EXPRESSION",
+                                  "required": true,
+                                  "key": "message"
+                                }
+                              ],
+                              "key": "application/json"
+                            }
+                          ],
+                          "key": "404"
+                        }
+                      ],
+                      "protocols": [
+                        "HTTPS"
+                      ],
+                      "is": [
+                        "withNoBodyResponse",
+                        "withNotFoundError"
+                      ],
+                      "displayName": "Add user to a team",
+                      "method": "post",
+                      "allUriParameters": [
+                        {
+                          "name": "team_id",
+                          "displayName": "team_id",
+                          "typePropertyKind": "TYPE_EXPRESSION",
+                          "type": "string",
+                          "required": true,
+                          "key": "team_id"
+                        },
+                        {
+                          "name": "user_username",
+                          "displayName": "user_username",
+                          "typePropertyKind": "TYPE_EXPRESSION",
+                          "type": "string",
+                          "required": true,
+                          "key": "user_username"
+                        }
+                      ]
+                    },
+                    {
+                      "responses": [
+                        {
+                          "code": "204",
+                          "key": "204"
+                        },
+                        {
+                          "code": "404",
+                          "body": [
+                            {
+                              "name": "Error",
+                              "displayName": "Error",
+                              "typePropertyKind": "TYPE_EXPRESSION",
+                              "type": "object",
+                              "additionalProperties": true,
+                              "properties": [
+                                {
+                                  "type": "string",
+                                  "displayName": "message",
+                                  "name": "message",
+                                  "typePropertyKind": "TYPE_EXPRESSION",
+                                  "required": true,
+                                  "key": "message"
+                                }
+                              ],
+                              "key": "application/json"
+                            }
+                          ],
+                          "key": "404"
+                        }
+                      ],
+                      "protocols": [
+                        "HTTPS"
+                      ],
+                      "is": [
+                        "withNoBodyResponse",
+                        "withNotFoundError"
+                      ],
+                      "displayName": "Remove user from a team",
+                      "method": "delete",
+                      "allUriParameters": [
+                        {
+                          "name": "team_id",
+                          "displayName": "team_id",
+                          "typePropertyKind": "TYPE_EXPRESSION",
+                          "type": "string",
+                          "required": true,
+                          "key": "team_id"
+                        },
+                        {
+                          "name": "user_username",
+                          "displayName": "user_username",
+                          "typePropertyKind": "TYPE_EXPRESSION",
+                          "type": "string",
+                          "required": true,
+                          "key": "user_username"
+                        }
+                      ]
+                    }
+                  ],
+                  "uriParameters": [
+                    {
+                      "name": "user_username",
+                      "displayName": "user_username",
+                      "typePropertyKind": "TYPE_EXPRESSION",
+                      "type": "string",
+                      "required": true,
+                      "key": "user_username"
+                    }
+                  ],
+                  "relativeUri": "/{user_username}",
+                  "displayName": "/{user_username}",
+                  "relativeUriPathSegments": [
+                    "{user_username}"
+                  ],
+                  "absoluteUri": "https://api.semaphoreci.com/v2/teams/{team_id}/users/{user_username}",
+                  "parentUrl": "/teams/{team_id}/users",
+                  "uniqueId": "teams__team_id__users__user_username_",
+                  "allUriParameters": [
+                    {
+                      "name": "team_id",
+                      "displayName": "team_id",
+                      "typePropertyKind": "TYPE_EXPRESSION",
+                      "type": "string",
+                      "required": true,
+                      "key": "team_id"
+                    },
+                    {
+                      "name": "user_username",
+                      "displayName": "user_username",
+                      "typePropertyKind": "TYPE_EXPRESSION",
+                      "type": "string",
+                      "required": true,
+                      "key": "user_username"
+                    }
+                  ]
+                }
+              ],
+              "relativeUriPathSegments": [
+                "users"
+              ],
+              "absoluteUri": "https://api.semaphoreci.com/v2/teams/{team_id}/users",
+              "parentUrl": "/teams/{team_id}",
+              "uniqueId": "teams__team_id__users",
+              "allUriParameters": [
+                {
+                  "name": "team_id",
+                  "displayName": "team_id",
+                  "typePropertyKind": "TYPE_EXPRESSION",
+                  "type": "string",
+                  "required": true,
+                  "key": "team_id"
+                }
+              ]
+            },
+            {
+              "methods": [
+                {
+                  "responses": [
+                    {
+                      "code": "200",
+                      "body": [
+                        {
+                          "name": "application/json",
+                          "displayName": "application/json",
+                          "typePropertyKind": "TYPE_EXPRESSION",
+                          "type": "array",
+                          "items": {
+                            "additionalProperties": true,
+                            "type": "object",
+                            "displayName": "Project",
+                            "name": "Project",
+                            "typePropertyKind": "TYPE_EXPRESSION",
+                            "properties": [
+                              {
+                                "displayName": "id",
+                                "type": "string",
+                                "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
+                                "name": "id",
+                                "typePropertyKind": "TYPE_EXPRESSION",
+                                "required": true,
+                                "examples": [
+                                  {
+                                    "value": "86e78b7e-2f9c-45a7-9939-ec2c9f6f64b5",
+                                    "strict": true,
+                                    "structuredValue": "86e78b7e-2f9c-45a7-9939-ec2c9f6f64b5"
+                                  }
+                                ],
+                                "key": "id"
+                              },
+                              {
+                                "type": "string",
+                                "displayName": "name",
+                                "name": "name",
+                                "typePropertyKind": "TYPE_EXPRESSION",
+                                "required": true,
+                                "examples": [
+                                  {
+                                    "value": "elixir-lang",
+                                    "strict": true,
+                                    "structuredValue": "elixir-lang"
+                                  }
+                                ],
+                                "key": "name"
+                              },
+                              {
+                                "format": "rfc3339",
+                                "displayName": "updated_at",
+                                "type": "datetime",
+                                "name": "updated_at",
+                                "typePropertyKind": "TYPE_EXPRESSION",
+                                "required": true,
+                                "key": "updated_at"
+                              },
+                              {
+                                "format": "rfc3339",
+                                "displayName": "created_at",
+                                "type": "datetime",
+                                "name": "created_at",
+                                "typePropertyKind": "TYPE_EXPRESSION",
+                                "required": true,
+                                "key": "created_at"
+                              }
+                            ]
+                          },
+                          "key": "application/json"
+                        }
+                      ],
+                      "key": "200"
+                    },
+                    {
+                      "code": "404",
+                      "body": [
+                        {
+                          "name": "Error",
+                          "displayName": "Error",
+                          "typePropertyKind": "TYPE_EXPRESSION",
+                          "type": "object",
+                          "additionalProperties": true,
+                          "properties": [
+                            {
+                              "type": "string",
+                              "displayName": "message",
+                              "name": "message",
+                              "typePropertyKind": "TYPE_EXPRESSION",
+                              "required": true,
+                              "key": "message"
+                            }
+                          ],
+                          "key": "application/json"
+                        }
+                      ],
+                      "key": "404"
+                    }
+                  ],
+                  "protocols": [
+                    "HTTPS"
+                  ],
+                  "is": [
+                    {
+                      "withResponseItems": {
+                        "item": "Project"
+                      }
+                    },
+                    "withNotFoundError"
+                  ],
+                  "displayName": "List project added to a team",
+                  "method": "get",
+                  "allUriParameters": [
+                    {
+                      "name": "team_id",
+                      "displayName": "team_id",
+                      "typePropertyKind": "TYPE_EXPRESSION",
+                      "type": "string",
+                      "required": true,
+                      "key": "team_id"
+                    }
+                  ]
+                }
+              ],
+              "relativeUri": "/projects",
+              "displayName": "/projects",
+              "resources": [
+                {
+                  "methods": [
+                    {
+                      "responses": [
+                        {
+                          "code": "204",
+                          "key": "204"
+                        },
+                        {
+                          "code": "404",
+                          "body": [
+                            {
+                              "name": "Error",
+                              "displayName": "Error",
+                              "typePropertyKind": "TYPE_EXPRESSION",
+                              "type": "object",
+                              "additionalProperties": true,
+                              "properties": [
+                                {
+                                  "type": "string",
+                                  "displayName": "message",
+                                  "name": "message",
+                                  "typePropertyKind": "TYPE_EXPRESSION",
+                                  "required": true,
+                                  "key": "message"
+                                }
+                              ],
+                              "key": "application/json"
+                            }
+                          ],
+                          "key": "404"
+                        }
+                      ],
+                      "protocols": [
+                        "HTTPS"
+                      ],
+                      "is": [
+                        "withNoBodyResponse",
+                        "withNotFoundError"
+                      ],
+                      "displayName": "Add project to a team",
+                      "method": "post",
+                      "allUriParameters": [
+                        {
+                          "name": "team_id",
+                          "displayName": "team_id",
+                          "typePropertyKind": "TYPE_EXPRESSION",
+                          "type": "string",
+                          "required": true,
+                          "key": "team_id"
+                        },
+                        {
+                          "name": "project_id",
+                          "displayName": "project_id",
+                          "typePropertyKind": "TYPE_EXPRESSION",
+                          "type": "string",
+                          "required": true,
+                          "key": "project_id"
+                        }
+                      ]
+                    },
+                    {
+                      "responses": [
+                        {
+                          "code": "204",
+                          "key": "204"
+                        },
+                        {
+                          "code": "404",
+                          "body": [
+                            {
+                              "name": "Error",
+                              "displayName": "Error",
+                              "typePropertyKind": "TYPE_EXPRESSION",
+                              "type": "object",
+                              "additionalProperties": true,
+                              "properties": [
+                                {
+                                  "type": "string",
+                                  "displayName": "message",
+                                  "name": "message",
+                                  "typePropertyKind": "TYPE_EXPRESSION",
+                                  "required": true,
+                                  "key": "message"
+                                }
+                              ],
+                              "key": "application/json"
+                            }
+                          ],
+                          "key": "404"
+                        }
+                      ],
+                      "protocols": [
+                        "HTTPS"
+                      ],
+                      "is": [
+                        "withNoBodyResponse",
+                        "withNotFoundError"
+                      ],
+                      "displayName": "Remove project from a team",
+                      "method": "delete",
+                      "allUriParameters": [
+                        {
+                          "name": "team_id",
+                          "displayName": "team_id",
+                          "typePropertyKind": "TYPE_EXPRESSION",
+                          "type": "string",
+                          "required": true,
+                          "key": "team_id"
+                        },
+                        {
+                          "name": "project_id",
+                          "displayName": "project_id",
+                          "typePropertyKind": "TYPE_EXPRESSION",
+                          "type": "string",
+                          "required": true,
+                          "key": "project_id"
+                        }
+                      ]
+                    }
+                  ],
+                  "uriParameters": [
+                    {
+                      "name": "project_id",
+                      "displayName": "project_id",
+                      "typePropertyKind": "TYPE_EXPRESSION",
+                      "type": "string",
+                      "required": true,
+                      "key": "project_id"
+                    }
+                  ],
+                  "relativeUri": "/{project_id}",
+                  "displayName": "/{project_id}",
+                  "relativeUriPathSegments": [
+                    "{project_id}"
+                  ],
+                  "absoluteUri": "https://api.semaphoreci.com/v2/teams/{team_id}/projects/{project_id}",
+                  "parentUrl": "/teams/{team_id}/projects",
+                  "uniqueId": "teams__team_id__projects__project_id_",
+                  "allUriParameters": [
+                    {
+                      "name": "team_id",
+                      "displayName": "team_id",
+                      "typePropertyKind": "TYPE_EXPRESSION",
+                      "type": "string",
+                      "required": true,
+                      "key": "team_id"
+                    },
+                    {
+                      "name": "project_id",
+                      "displayName": "project_id",
+                      "typePropertyKind": "TYPE_EXPRESSION",
+                      "type": "string",
+                      "required": true,
+                      "key": "project_id"
+                    }
+                  ]
+                }
+              ],
+              "relativeUriPathSegments": [
+                "projects"
+              ],
+              "absoluteUri": "https://api.semaphoreci.com/v2/teams/{team_id}/projects",
+              "parentUrl": "/teams/{team_id}",
+              "uniqueId": "teams__team_id__projects",
+              "allUriParameters": [
+                {
+                  "name": "team_id",
+                  "displayName": "team_id",
+                  "typePropertyKind": "TYPE_EXPRESSION",
+                  "type": "string",
+                  "required": true,
+                  "key": "team_id"
+                }
+              ]
+            }
+          ],
+          "relativeUriPathSegments": [
+            "{team_id}"
+          ],
+          "absoluteUri": "https://api.semaphoreci.com/v2/teams/{team_id}",
+          "parentUrl": "/teams",
+          "uniqueId": "teams__team_id_",
+          "allUriParameters": [
+            {
+              "name": "team_id",
+              "displayName": "team_id",
+              "typePropertyKind": "TYPE_EXPRESSION",
+              "type": "string",
+              "required": true,
+              "key": "team_id"
+            }
+          ]
+        }
+      ],
+      "relativeUriPathSegments": [
+        "teams"
+      ],
+      "absoluteUri": "https://api.semaphoreci.com/v2/teams",
+      "parentUrl": "",
+      "uniqueId": "teams",
+      "allUriParameters": []
+    },
+    {
+      "relativeUri": "/projects",
+      "displayName": "Projects",
+      "resources": [
+        {
+          "uriParameters": [
+            {
+              "name": "project_id",
+              "displayName": "project_id",
+              "typePropertyKind": "TYPE_EXPRESSION",
+              "type": "string",
+              "required": true,
+              "key": "project_id"
+            }
+          ],
+          "relativeUri": "/{project_id}",
+          "displayName": "/{project_id}",
+          "resources": [
+            {
+              "methods": [
+                {
+                  "responses": [
+                    {
+                      "code": "200",
+                      "body": [
+                        {
+                          "name": "application/json",
+                          "displayName": "application/json",
+                          "typePropertyKind": "TYPE_EXPRESSION",
+                          "type": "array",
+                          "items": {
+                            "additionalProperties": true,
+                            "displayName": "SharedConfig",
+                            "type": "object",
+                            "name": "SharedConfig",
+                            "typePropertyKind": "TYPE_EXPRESSION",
+                            "properties": [
+                              {
+                                "displayName": "name",
+                                "type": "string",
+                                "example": "AWS Tokens",
+                                "required": true,
+                                "key": "name"
+                              },
+                              {
+                                "displayName": "description",
+                                "type": "string",
+                                "example": "AWS tokens for deployment",
+                                "required": false,
+                                "key": "description"
+                              },
+                              {
+                                "displayName": "id",
+                                "type": "string",
+                                "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
+                                "name": "id",
+                                "typePropertyKind": "TYPE_EXPRESSION",
+                                "required": true,
+                                "examples": [
+                                  {
+                                    "value": "86e78b7e-2f9c-45a7-9939-ec2c9f6f64b5",
+                                    "strict": true,
+                                    "structuredValue": "86e78b7e-2f9c-45a7-9939-ec2c9f6f64b5"
+                                  }
+                                ],
+                                "key": "id"
+                              },
+                              {
+                                "type": "string",
+                                "displayName": "url",
+                                "name": "url",
+                                "typePropertyKind": "TYPE_EXPRESSION",
+                                "required": true,
+                                "examples": [
+                                  {
+                                    "value": "https://api.semaphoreci.com/v2/shared_configs/86e78b7e-2f9c-45a7-9939-ec2c9f6f64b5",
+                                    "strict": true,
+                                    "structuredValue": "https://api.semaphoreci.com/v2/shared_configs/86e78b7e-2f9c-45a7-9939-ec2c9f6f64b5"
+                                  }
+                                ],
+                                "key": "url"
+                              },
+                              {
+                                "format": "rfc3339",
+                                "displayName": "created_at",
+                                "type": "datetime",
+                                "name": "created_at",
+                                "typePropertyKind": "TYPE_EXPRESSION",
+                                "required": true,
+                                "key": "created_at"
+                              },
+                              {
+                                "format": "rfc3339",
+                                "displayName": "updated_at",
+                                "type": "datetime",
+                                "name": "updated_at",
+                                "typePropertyKind": "TYPE_EXPRESSION",
+                                "required": true,
+                                "key": "updated_at"
+                              }
+                            ]
+                          },
+                          "key": "application/json"
+                        }
+                      ],
+                      "key": "200"
+                    },
+                    {
+                      "code": "404",
+                      "body": [
+                        {
+                          "name": "Error",
+                          "displayName": "Error",
+                          "typePropertyKind": "TYPE_EXPRESSION",
+                          "type": "object",
+                          "additionalProperties": true,
+                          "properties": [
+                            {
+                              "type": "string",
+                              "displayName": "message",
+                              "name": "message",
+                              "typePropertyKind": "TYPE_EXPRESSION",
+                              "required": true,
+                              "key": "message"
+                            }
+                          ],
+                          "key": "application/json"
+                        }
+                      ],
+                      "key": "404"
+                    }
+                  ],
+                  "protocols": [
+                    "HTTPS"
+                  ],
+                  "is": [
+                    {
+                      "withResponseItems": {
+                        "item": "SharedConfig"
+                      }
+                    },
+                    "withNotFoundError"
+                  ],
+                  "displayName": "List shared configurations attached to a project",
+                  "method": "get",
+                  "allUriParameters": [
+                    {
+                      "name": "project_id",
+                      "displayName": "project_id",
+                      "typePropertyKind": "TYPE_EXPRESSION",
+                      "type": "string",
+                      "required": true,
+                      "key": "project_id"
+                    }
+                  ]
+                }
+              ],
+              "relativeUri": "/shared_configs",
+              "displayName": "/shared_configs",
+              "resources": [
+                {
+                  "methods": [
+                    {
+                      "responses": [
+                        {
+                          "code": "200",
+                          "body": [
+                            {
+                              "name": "SharedConfig",
+                              "displayName": "SharedConfig",
+                              "typePropertyKind": "TYPE_EXPRESSION",
+                              "type": "object",
+                              "additionalProperties": true,
+                              "properties": [
+                                {
+                                  "displayName": "name",
+                                  "type": "string",
+                                  "example": "AWS Tokens",
+                                  "required": true,
+                                  "key": "name"
+                                },
+                                {
+                                  "displayName": "description",
+                                  "type": "string",
+                                  "example": "AWS tokens for deployment",
+                                  "required": false,
+                                  "key": "description"
+                                },
+                                {
+                                  "displayName": "id",
+                                  "type": "string",
+                                  "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
+                                  "name": "id",
+                                  "typePropertyKind": "TYPE_EXPRESSION",
+                                  "required": true,
+                                  "examples": [
+                                    {
+                                      "value": "86e78b7e-2f9c-45a7-9939-ec2c9f6f64b5",
+                                      "strict": true,
+                                      "structuredValue": "86e78b7e-2f9c-45a7-9939-ec2c9f6f64b5"
+                                    }
+                                  ],
+                                  "key": "id"
+                                },
+                                {
+                                  "type": "string",
+                                  "displayName": "url",
+                                  "name": "url",
+                                  "typePropertyKind": "TYPE_EXPRESSION",
+                                  "required": true,
+                                  "examples": [
+                                    {
+                                      "value": "https://api.semaphoreci.com/v2/shared_configs/86e78b7e-2f9c-45a7-9939-ec2c9f6f64b5",
+                                      "strict": true,
+                                      "structuredValue": "https://api.semaphoreci.com/v2/shared_configs/86e78b7e-2f9c-45a7-9939-ec2c9f6f64b5"
+                                    }
+                                  ],
+                                  "key": "url"
+                                },
+                                {
+                                  "format": "rfc3339",
+                                  "displayName": "created_at",
+                                  "type": "datetime",
+                                  "name": "created_at",
+                                  "typePropertyKind": "TYPE_EXPRESSION",
+                                  "required": true,
+                                  "key": "created_at"
+                                },
+                                {
+                                  "format": "rfc3339",
+                                  "displayName": "updated_at",
+                                  "type": "datetime",
+                                  "name": "updated_at",
+                                  "typePropertyKind": "TYPE_EXPRESSION",
+                                  "required": true,
+                                  "key": "updated_at"
+                                }
+                              ],
+                              "key": "application/json"
+                            }
+                          ],
+                          "key": "200"
+                        },
+                        {
+                          "code": "404",
+                          "body": [
+                            {
+                              "name": "Error",
+                              "displayName": "Error",
+                              "typePropertyKind": "TYPE_EXPRESSION",
+                              "type": "object",
+                              "additionalProperties": true,
+                              "properties": [
+                                {
+                                  "type": "string",
+                                  "displayName": "message",
+                                  "name": "message",
+                                  "typePropertyKind": "TYPE_EXPRESSION",
+                                  "required": true,
+                                  "key": "message"
+                                }
+                              ],
+                              "key": "application/json"
+                            }
+                          ],
+                          "key": "404"
+                        }
+                      ],
+                      "protocols": [
+                        "HTTPS"
+                      ],
+                      "is": [
+                        {
+                          "withResponseItem": {
+                            "item": "SharedConfig"
+                          }
+                        },
+                        "withNotFoundError"
+                      ],
+                      "displayName": "Attach a shared configuration to a project",
+                      "method": "post",
+                      "allUriParameters": [
+                        {
+                          "name": "project_id",
+                          "displayName": "project_id",
+                          "typePropertyKind": "TYPE_EXPRESSION",
+                          "type": "string",
+                          "required": true,
+                          "key": "project_id"
+                        },
+                        {
+                          "name": "shared_config_id",
+                          "displayName": "shared_config_id",
+                          "typePropertyKind": "TYPE_EXPRESSION",
+                          "type": "string",
+                          "required": true,
+                          "key": "shared_config_id"
+                        }
+                      ]
+                    },
+                    {
+                      "responses": [
+                        {
+                          "code": "204",
+                          "key": "204"
+                        },
+                        {
+                          "code": "404",
+                          "body": [
+                            {
+                              "name": "Error",
+                              "displayName": "Error",
+                              "typePropertyKind": "TYPE_EXPRESSION",
+                              "type": "object",
+                              "additionalProperties": true,
+                              "properties": [
+                                {
+                                  "type": "string",
+                                  "displayName": "message",
+                                  "name": "message",
+                                  "typePropertyKind": "TYPE_EXPRESSION",
+                                  "required": true,
+                                  "key": "message"
+                                }
+                              ],
+                              "key": "application/json"
+                            }
+                          ],
+                          "key": "404"
+                        }
+                      ],
+                      "protocols": [
+                        "HTTPS"
+                      ],
+                      "is": [
+                        "withNoBodyResponse",
+                        "withNotFoundError"
+                      ],
+                      "displayName": "Dettach a shared configuration from a project",
+                      "method": "delete",
+                      "allUriParameters": [
+                        {
+                          "name": "project_id",
+                          "displayName": "project_id",
+                          "typePropertyKind": "TYPE_EXPRESSION",
+                          "type": "string",
+                          "required": true,
+                          "key": "project_id"
+                        },
+                        {
+                          "name": "shared_config_id",
+                          "displayName": "shared_config_id",
+                          "typePropertyKind": "TYPE_EXPRESSION",
+                          "type": "string",
+                          "required": true,
+                          "key": "shared_config_id"
+                        }
+                      ]
+                    }
+                  ],
+                  "uriParameters": [
+                    {
+                      "name": "shared_config_id",
+                      "displayName": "shared_config_id",
+                      "typePropertyKind": "TYPE_EXPRESSION",
+                      "type": "string",
+                      "required": true,
+                      "key": "shared_config_id"
+                    }
+                  ],
+                  "relativeUri": "/{shared_config_id}",
+                  "displayName": "/{shared_config_id}",
+                  "relativeUriPathSegments": [
+                    "{shared_config_id}"
+                  ],
+                  "absoluteUri": "https://api.semaphoreci.com/v2/projects/{project_id}/shared_configs/{shared_config_id}",
+                  "parentUrl": "/projects/{project_id}/shared_configs",
+                  "uniqueId": "projects__project_id__shared_configs__shared_config_id_",
+                  "allUriParameters": [
+                    {
+                      "name": "project_id",
+                      "displayName": "project_id",
+                      "typePropertyKind": "TYPE_EXPRESSION",
+                      "type": "string",
+                      "required": true,
+                      "key": "project_id"
+                    },
+                    {
+                      "name": "shared_config_id",
+                      "displayName": "shared_config_id",
+                      "typePropertyKind": "TYPE_EXPRESSION",
+                      "type": "string",
+                      "required": true,
+                      "key": "shared_config_id"
+                    }
+                  ]
+                }
+              ],
+              "relativeUriPathSegments": [
+                "shared_configs"
+              ],
+              "absoluteUri": "https://api.semaphoreci.com/v2/projects/{project_id}/shared_configs",
+              "parentUrl": "/projects/{project_id}",
+              "uniqueId": "projects__project_id__shared_configs",
+              "allUriParameters": [
+                {
+                  "name": "project_id",
+                  "displayName": "project_id",
+                  "typePropertyKind": "TYPE_EXPRESSION",
+                  "type": "string",
+                  "required": true,
+                  "key": "project_id"
+                }
+              ]
+            },
+            {
+              "methods": [
+                {
+                  "responses": [
+                    {
+                      "code": "200",
+                      "body": [
+                        {
+                          "name": "application/json",
+                          "displayName": "application/json",
+                          "typePropertyKind": "TYPE_EXPRESSION",
+                          "type": "array",
+                          "items": {
+                            "additionalProperties": true,
+                            "displayName": "EnvVar",
+                            "type": "object",
+                            "name": "EnvVar",
+                            "typePropertyKind": "TYPE_EXPRESSION",
+                            "properties": [
+                              {
+                                "displayName": "name",
+                                "type": "string",
+                                "example": "API_TOKEN",
+                                "required": true,
+                                "key": "name"
+                              },
+                              {
+                                "displayName": "content",
+                                "type": "string",
+                                "example": "8CgLAxXn",
+                                "required": true,
+                                "key": "content"
+                              },
+                              {
+                                "displayName": "encrypted",
+                                "type": "boolean",
+                                "example": true,
+                                "required": true,
+                                "key": "encrypted"
+                              },
+                              {
+                                "displayName": "id",
+                                "type": "string",
+                                "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
+                                "name": "id",
+                                "typePropertyKind": "TYPE_EXPRESSION",
+                                "required": true,
+                                "examples": [
+                                  {
+                                    "value": "86e78b7e-2f9c-45a7-9939-ec2c9f6f64b5",
+                                    "strict": true,
+                                    "structuredValue": "86e78b7e-2f9c-45a7-9939-ec2c9f6f64b5"
+                                  }
+                                ],
+                                "key": "id"
+                              },
+                              {
+                                "type": "string",
+                                "displayName": "url",
+                                "name": "url",
+                                "typePropertyKind": "TYPE_EXPRESSION",
+                                "required": true,
+                                "examples": [
+                                  {
+                                    "value": "https://api.semaphoreci.com/v2/env_vars/86e78b7e-2f9c-45a7-9939-ec2c9f6f64b5",
+                                    "strict": true,
+                                    "structuredValue": "https://api.semaphoreci.com/v2/env_vars/86e78b7e-2f9c-45a7-9939-ec2c9f6f64b5"
+                                  }
+                                ],
+                                "key": "url"
+                              },
+                              {
+                                "type": "boolean",
+                                "displayName": "shared",
+                                "name": "shared",
+                                "typePropertyKind": "TYPE_EXPRESSION",
+                                "required": true,
+                                "examples": [
+                                  {
+                                    "value": "true",
+                                    "strict": true,
+                                    "structuredValue": true
+                                  }
+                                ],
+                                "key": "shared"
+                              },
+                              {
+                                "format": "rfc3339",
+                                "displayName": "created_at",
+                                "type": "datetime",
+                                "name": "created_at",
+                                "typePropertyKind": "TYPE_EXPRESSION",
+                                "required": true,
+                                "key": "created_at"
+                              },
+                              {
+                                "format": "rfc3339",
+                                "displayName": "updated_at",
+                                "type": "datetime",
+                                "name": "updated_at",
+                                "typePropertyKind": "TYPE_EXPRESSION",
+                                "required": true,
+                                "key": "updated_at"
+                              }
+                            ]
+                          },
+                          "key": "application/json"
+                        }
+                      ],
+                      "key": "200"
+                    },
+                    {
+                      "code": "404",
+                      "body": [
+                        {
+                          "name": "Error",
+                          "displayName": "Error",
+                          "typePropertyKind": "TYPE_EXPRESSION",
+                          "type": "object",
+                          "additionalProperties": true,
+                          "properties": [
+                            {
+                              "type": "string",
+                              "displayName": "message",
+                              "name": "message",
+                              "typePropertyKind": "TYPE_EXPRESSION",
+                              "required": true,
+                              "key": "message"
+                            }
+                          ],
+                          "key": "application/json"
+                        }
+                      ],
+                      "key": "404"
+                    }
+                  ],
+                  "protocols": [
+                    "HTTPS"
+                  ],
+                  "is": [
+                    {
+                      "withResponseItems": {
+                        "item": "EnvVar"
+                      }
+                    },
+                    "withNotFoundError"
+                  ],
+                  "displayName": "List environment variables connected to a project",
+                  "method": "get",
+                  "allUriParameters": [
+                    {
+                      "name": "project_id",
+                      "displayName": "project_id",
+                      "typePropertyKind": "TYPE_EXPRESSION",
+                      "type": "string",
+                      "required": true,
+                      "key": "project_id"
+                    }
+                  ]
+                }
+              ],
+              "relativeUri": "/env_vars",
+              "displayName": "/env_vars",
+              "resources": [
+                {
+                  "methods": [
+                    {
+                      "responses": [
+                        {
+                          "code": "204",
+                          "key": "204"
+                        },
+                        {
+                          "code": "404",
+                          "body": [
+                            {
+                              "name": "Error",
+                              "displayName": "Error",
+                              "typePropertyKind": "TYPE_EXPRESSION",
+                              "type": "object",
+                              "additionalProperties": true,
+                              "properties": [
+                                {
+                                  "type": "string",
+                                  "displayName": "message",
+                                  "name": "message",
+                                  "typePropertyKind": "TYPE_EXPRESSION",
+                                  "required": true,
+                                  "key": "message"
+                                }
+                              ],
+                              "key": "application/json"
+                            }
+                          ],
+                          "key": "404"
+                        }
+                      ],
+                      "protocols": [
+                        "HTTPS"
+                      ],
+                      "is": [
+                        "withNoBodyResponse",
+                        "withNotFoundError"
+                      ],
+                      "displayName": "Connect a shared environment variable to a project",
+                      "method": "post",
+                      "allUriParameters": [
+                        {
+                          "name": "project_id",
+                          "displayName": "project_id",
+                          "typePropertyKind": "TYPE_EXPRESSION",
+                          "type": "string",
+                          "required": true,
+                          "key": "project_id"
+                        },
+                        {
+                          "name": "env_var_id",
+                          "displayName": "env_var_id",
+                          "typePropertyKind": "TYPE_EXPRESSION",
+                          "type": "string",
+                          "required": true,
+                          "key": "env_var_id"
+                        }
+                      ]
+                    },
+                    {
+                      "responses": [
+                        {
+                          "code": "204",
+                          "key": "204"
+                        },
+                        {
+                          "code": "404",
+                          "body": [
+                            {
+                              "name": "Error",
+                              "displayName": "Error",
+                              "typePropertyKind": "TYPE_EXPRESSION",
+                              "type": "object",
+                              "additionalProperties": true,
+                              "properties": [
+                                {
+                                  "type": "string",
+                                  "displayName": "message",
+                                  "name": "message",
+                                  "typePropertyKind": "TYPE_EXPRESSION",
+                                  "required": true,
+                                  "key": "message"
+                                }
+                              ],
+                              "key": "application/json"
+                            }
+                          ],
+                          "key": "404"
+                        }
+                      ],
+                      "protocols": [
+                        "HTTPS"
+                      ],
+                      "is": [
+                        "withNoBodyResponse",
+                        "withNotFoundError"
+                      ],
+                      "displayName": "Dissconnect a shared environment variable from a project",
+                      "method": "delete",
+                      "allUriParameters": [
+                        {
+                          "name": "project_id",
+                          "displayName": "project_id",
+                          "typePropertyKind": "TYPE_EXPRESSION",
+                          "type": "string",
+                          "required": true,
+                          "key": "project_id"
+                        },
+                        {
+                          "name": "env_var_id",
+                          "displayName": "env_var_id",
+                          "typePropertyKind": "TYPE_EXPRESSION",
+                          "type": "string",
+                          "required": true,
+                          "key": "env_var_id"
+                        }
+                      ]
+                    }
+                  ],
+                  "uriParameters": [
+                    {
+                      "name": "env_var_id",
+                      "displayName": "env_var_id",
+                      "typePropertyKind": "TYPE_EXPRESSION",
+                      "type": "string",
+                      "required": true,
+                      "key": "env_var_id"
+                    }
+                  ],
+                  "relativeUri": "/{env_var_id}",
+                  "displayName": "/{env_var_id}",
+                  "relativeUriPathSegments": [
+                    "{env_var_id}"
+                  ],
+                  "absoluteUri": "https://api.semaphoreci.com/v2/projects/{project_id}/env_vars/{env_var_id}",
+                  "parentUrl": "/projects/{project_id}/env_vars",
+                  "uniqueId": "projects__project_id__env_vars__env_var_id_",
+                  "allUriParameters": [
+                    {
+                      "name": "project_id",
+                      "displayName": "project_id",
+                      "typePropertyKind": "TYPE_EXPRESSION",
+                      "type": "string",
+                      "required": true,
+                      "key": "project_id"
+                    },
+                    {
+                      "name": "env_var_id",
+                      "displayName": "env_var_id",
+                      "typePropertyKind": "TYPE_EXPRESSION",
+                      "type": "string",
+                      "required": true,
+                      "key": "env_var_id"
+                    }
+                  ]
+                }
+              ],
+              "relativeUriPathSegments": [
+                "env_vars"
+              ],
+              "absoluteUri": "https://api.semaphoreci.com/v2/projects/{project_id}/env_vars",
+              "parentUrl": "/projects/{project_id}",
+              "uniqueId": "projects__project_id__env_vars",
+              "allUriParameters": [
+                {
+                  "name": "project_id",
+                  "displayName": "project_id",
+                  "typePropertyKind": "TYPE_EXPRESSION",
+                  "type": "string",
+                  "required": true,
+                  "key": "project_id"
+                }
+              ]
+            },
+            {
+              "methods": [
+                {
+                  "responses": [
+                    {
+                      "code": "200",
+                      "body": [
+                        {
+                          "name": "application/json",
+                          "displayName": "application/json",
+                          "typePropertyKind": "TYPE_EXPRESSION",
+                          "type": "array",
+                          "items": {
+                            "additionalProperties": true,
+                            "displayName": "ConfigFile",
+                            "type": "object",
+                            "name": "ConfigFile",
+                            "typePropertyKind": "TYPE_EXPRESSION",
+                            "properties": [
+                              {
+                                "displayName": "path",
+                                "type": "string",
+                                "example": ".credentials",
+                                "required": true,
+                                "key": "path"
+                              },
+                              {
+                                "displayName": "content",
+                                "type": "string",
+                                "example": "password: ec2c9f6f64b5",
+                                "required": true,
+                                "key": "content"
+                              },
+                              {
+                                "displayName": "encrypted",
+                                "type": "boolean",
+                                "example": true,
+                                "required": true,
+                                "key": "encrypted"
+                              },
+                              {
+                                "displayName": "id",
+                                "type": "string",
+                                "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
+                                "name": "id",
+                                "typePropertyKind": "TYPE_EXPRESSION",
+                                "required": true,
+                                "examples": [
+                                  {
+                                    "value": "86e78b7e-2f9c-45a7-9939-ec2c9f6f64b5",
+                                    "strict": true,
+                                    "structuredValue": "86e78b7e-2f9c-45a7-9939-ec2c9f6f64b5"
+                                  }
+                                ],
+                                "key": "id"
+                              },
+                              {
+                                "type": "string",
+                                "displayName": "url",
+                                "name": "url",
+                                "typePropertyKind": "TYPE_EXPRESSION",
+                                "required": true,
+                                "examples": [
+                                  {
+                                    "value": "https://api.semaphoreci.com/v2/config_files/86e78b7e-2f9c-45a7-9939-ec2c9f6f64b5",
+                                    "strict": true,
+                                    "structuredValue": "https://api.semaphoreci.com/v2/config_files/86e78b7e-2f9c-45a7-9939-ec2c9f6f64b5"
+                                  }
+                                ],
+                                "key": "url"
+                              },
+                              {
+                                "type": "boolean",
+                                "displayName": "shared",
+                                "name": "shared",
+                                "typePropertyKind": "TYPE_EXPRESSION",
+                                "required": true,
+                                "examples": [
+                                  {
+                                    "value": "true",
+                                    "strict": true,
+                                    "structuredValue": true
+                                  }
+                                ],
+                                "key": "shared"
+                              },
+                              {
+                                "format": "rfc3339",
+                                "displayName": "created_at",
+                                "type": "datetime",
+                                "name": "created_at",
+                                "typePropertyKind": "TYPE_EXPRESSION",
+                                "required": true,
+                                "key": "created_at"
+                              },
+                              {
+                                "format": "rfc3339",
+                                "displayName": "updated_at",
+                                "type": "datetime",
+                                "name": "updated_at",
+                                "typePropertyKind": "TYPE_EXPRESSION",
+                                "required": true,
+                                "key": "updated_at"
+                              }
+                            ]
+                          },
+                          "key": "application/json"
+                        }
+                      ],
+                      "key": "200"
+                    },
+                    {
+                      "code": "404",
+                      "body": [
+                        {
+                          "name": "Error",
+                          "displayName": "Error",
+                          "typePropertyKind": "TYPE_EXPRESSION",
+                          "type": "object",
+                          "additionalProperties": true,
+                          "properties": [
+                            {
+                              "type": "string",
+                              "displayName": "message",
+                              "name": "message",
+                              "typePropertyKind": "TYPE_EXPRESSION",
+                              "required": true,
+                              "key": "message"
+                            }
+                          ],
+                          "key": "application/json"
+                        }
+                      ],
+                      "key": "404"
+                    }
+                  ],
+                  "protocols": [
+                    "HTTPS"
+                  ],
+                  "is": [
+                    {
+                      "withResponseItems": {
+                        "item": "ConfigFile"
+                      }
+                    },
+                    "withNotFoundError"
+                  ],
+                  "displayName": "List config files connected to a project",
+                  "method": "get",
+                  "allUriParameters": [
+                    {
+                      "name": "project_id",
+                      "displayName": "project_id",
+                      "typePropertyKind": "TYPE_EXPRESSION",
+                      "type": "string",
+                      "required": true,
+                      "key": "project_id"
+                    }
+                  ]
+                }
+              ],
+              "relativeUri": "/config_files",
+              "displayName": "/config_files",
+              "resources": [
+                {
+                  "methods": [
+                    {
+                      "responses": [
+                        {
+                          "code": "204",
+                          "key": "204"
+                        },
+                        {
+                          "code": "404",
+                          "body": [
+                            {
+                              "name": "Error",
+                              "displayName": "Error",
+                              "typePropertyKind": "TYPE_EXPRESSION",
+                              "type": "object",
+                              "additionalProperties": true,
+                              "properties": [
+                                {
+                                  "type": "string",
+                                  "displayName": "message",
+                                  "name": "message",
+                                  "typePropertyKind": "TYPE_EXPRESSION",
+                                  "required": true,
+                                  "key": "message"
+                                }
+                              ],
+                              "key": "application/json"
+                            }
+                          ],
+                          "key": "404"
+                        }
+                      ],
+                      "protocols": [
+                        "HTTPS"
+                      ],
+                      "is": [
+                        "withNoBodyResponse",
+                        "withNotFoundError"
+                      ],
+                      "displayName": "Connect a shared config file to a project",
+                      "method": "post",
+                      "allUriParameters": [
+                        {
+                          "name": "project_id",
+                          "displayName": "project_id",
+                          "typePropertyKind": "TYPE_EXPRESSION",
+                          "type": "string",
+                          "required": true,
+                          "key": "project_id"
+                        },
+                        {
+                          "name": "config_file_id",
+                          "displayName": "config_file_id",
+                          "typePropertyKind": "TYPE_EXPRESSION",
+                          "type": "string",
+                          "required": true,
+                          "key": "config_file_id"
+                        }
+                      ]
+                    },
+                    {
+                      "responses": [
+                        {
+                          "code": "204",
+                          "key": "204"
+                        },
+                        {
+                          "code": "404",
+                          "body": [
+                            {
+                              "name": "Error",
+                              "displayName": "Error",
+                              "typePropertyKind": "TYPE_EXPRESSION",
+                              "type": "object",
+                              "additionalProperties": true,
+                              "properties": [
+                                {
+                                  "type": "string",
+                                  "displayName": "message",
+                                  "name": "message",
+                                  "typePropertyKind": "TYPE_EXPRESSION",
+                                  "required": true,
+                                  "key": "message"
+                                }
+                              ],
+                              "key": "application/json"
+                            }
+                          ],
+                          "key": "404"
+                        }
+                      ],
+                      "protocols": [
+                        "HTTPS"
+                      ],
+                      "is": [
+                        "withNoBodyResponse",
+                        "withNotFoundError"
+                      ],
+                      "displayName": "Dissconnect a shared config file from a project",
+                      "method": "delete",
+                      "allUriParameters": [
+                        {
+                          "name": "project_id",
+                          "displayName": "project_id",
+                          "typePropertyKind": "TYPE_EXPRESSION",
+                          "type": "string",
+                          "required": true,
+                          "key": "project_id"
+                        },
+                        {
+                          "name": "config_file_id",
+                          "displayName": "config_file_id",
+                          "typePropertyKind": "TYPE_EXPRESSION",
+                          "type": "string",
+                          "required": true,
+                          "key": "config_file_id"
+                        }
+                      ]
+                    }
+                  ],
+                  "uriParameters": [
+                    {
+                      "name": "config_file_id",
+                      "displayName": "config_file_id",
+                      "typePropertyKind": "TYPE_EXPRESSION",
+                      "type": "string",
+                      "required": true,
+                      "key": "config_file_id"
+                    }
+                  ],
+                  "relativeUri": "/{config_file_id}",
+                  "displayName": "/{config_file_id}",
+                  "relativeUriPathSegments": [
+                    "{config_file_id}"
+                  ],
+                  "absoluteUri": "https://api.semaphoreci.com/v2/projects/{project_id}/config_files/{config_file_id}",
+                  "parentUrl": "/projects/{project_id}/config_files",
+                  "uniqueId": "projects__project_id__config_files__config_file_id_",
+                  "allUriParameters": [
+                    {
+                      "name": "project_id",
+                      "displayName": "project_id",
+                      "typePropertyKind": "TYPE_EXPRESSION",
+                      "type": "string",
+                      "required": true,
+                      "key": "project_id"
+                    },
+                    {
+                      "name": "config_file_id",
+                      "displayName": "config_file_id",
+                      "typePropertyKind": "TYPE_EXPRESSION",
+                      "type": "string",
+                      "required": true,
+                      "key": "config_file_id"
+                    }
+                  ]
+                }
+              ],
+              "relativeUriPathSegments": [
+                "config_files"
+              ],
+              "absoluteUri": "https://api.semaphoreci.com/v2/projects/{project_id}/config_files",
+              "parentUrl": "/projects/{project_id}",
+              "uniqueId": "projects__project_id__config_files",
+              "allUriParameters": [
+                {
+                  "name": "project_id",
+                  "displayName": "project_id",
+                  "typePropertyKind": "TYPE_EXPRESSION",
+                  "type": "string",
+                  "required": true,
+                  "key": "project_id"
+                }
+              ]
+            },
+            {
+              "methods": [
+                {
+                  "responses": [
+                    {
+                      "code": "200",
+                      "body": [
+                        {
+                          "name": "application/json",
+                          "displayName": "application/json",
+                          "typePropertyKind": "TYPE_EXPRESSION",
+                          "type": "array",
+                          "items": {
+                            "additionalProperties": true,
+                            "type": "object",
+                            "displayName": "User",
+                            "name": "User",
+                            "typePropertyKind": "TYPE_EXPRESSION",
+                            "properties": [
+                              {
+                                "displayName": "uid",
+                                "type": "string",
+                                "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
+                                "name": "uid",
+                                "typePropertyKind": "TYPE_EXPRESSION",
+                                "required": true,
+                                "examples": [
+                                  {
+                                    "value": "86e78b7e-2f9c-45a7-9939-ec2c9f6f64b5",
+                                    "strict": true,
+                                    "structuredValue": "86e78b7e-2f9c-45a7-9939-ec2c9f6f64b5"
+                                  }
+                                ],
+                                "key": "uid"
+                              },
+                              {
+                                "type": "string",
+                                "displayName": "username",
+                                "name": "username",
+                                "typePropertyKind": "TYPE_EXPRESSION",
+                                "required": true,
+                                "examples": [
+                                  {
+                                    "value": "johndoe",
+                                    "strict": true,
+                                    "structuredValue": "johndoe"
+                                  }
+                                ],
+                                "key": "username"
+                              },
+                              {
+                                "type": "string",
+                                "displayName": "name",
+                                "name": "name",
+                                "typePropertyKind": "TYPE_EXPRESSION",
+                                "required": true,
+                                "examples": [
+                                  {
+                                    "value": "John Doe",
+                                    "strict": true,
+                                    "structuredValue": "John Doe"
+                                  }
+                                ],
+                                "key": "name"
+                              },
+                              {
+                                "format": "rfc3339",
+                                "displayName": "created_at",
+                                "type": "datetime",
+                                "name": "created_at",
+                                "typePropertyKind": "TYPE_EXPRESSION",
+                                "required": true,
+                                "key": "created_at"
+                              },
+                              {
+                                "format": "rfc3339",
+                                "displayName": "updated_at",
+                                "type": "datetime",
+                                "name": "updated_at",
+                                "typePropertyKind": "TYPE_EXPRESSION",
+                                "required": true,
+                                "key": "updated_at"
+                              }
+                            ]
+                          },
+                          "key": "application/json"
+                        }
+                      ],
+                      "key": "200"
+                    },
+                    {
+                      "code": "404",
+                      "body": [
+                        {
+                          "name": "Error",
+                          "displayName": "Error",
+                          "typePropertyKind": "TYPE_EXPRESSION",
+                          "type": "object",
+                          "additionalProperties": true,
+                          "properties": [
+                            {
+                              "type": "string",
+                              "displayName": "message",
+                              "name": "message",
+                              "typePropertyKind": "TYPE_EXPRESSION",
+                              "required": true,
+                              "key": "message"
+                            }
+                          ],
+                          "key": "application/json"
+                        }
+                      ],
+                      "key": "404"
+                    }
+                  ],
+                  "protocols": [
+                    "HTTPS"
+                  ],
+                  "is": [
+                    {
+                      "withResponseItems": {
+                        "item": "User"
+                      }
+                    },
+                    "withNotFoundError"
+                  ],
+                  "displayName": "List all users fo a project",
+                  "method": "get",
+                  "allUriParameters": [
+                    {
+                      "name": "project_id",
+                      "displayName": "project_id",
+                      "typePropertyKind": "TYPE_EXPRESSION",
+                      "type": "string",
+                      "required": true,
+                      "key": "project_id"
+                    }
+                  ]
+                }
+              ],
+              "relativeUri": "/users",
+              "displayName": "/users",
+              "relativeUriPathSegments": [
+                "users"
+              ],
+              "absoluteUri": "https://api.semaphoreci.com/v2/projects/{project_id}/users",
+              "parentUrl": "/projects/{project_id}",
+              "uniqueId": "projects__project_id__users",
+              "allUriParameters": [
+                {
+                  "name": "project_id",
+                  "displayName": "project_id",
+                  "typePropertyKind": "TYPE_EXPRESSION",
+                  "type": "string",
+                  "required": true,
+                  "key": "project_id"
+                }
+              ]
+            }
+          ],
+          "relativeUriPathSegments": [
+            "{project_id}"
+          ],
+          "absoluteUri": "https://api.semaphoreci.com/v2/projects/{project_id}",
+          "parentUrl": "/projects",
+          "uniqueId": "projects__project_id_",
+          "allUriParameters": [
+            {
+              "name": "project_id",
+              "displayName": "project_id",
+              "typePropertyKind": "TYPE_EXPRESSION",
+              "type": "string",
+              "required": true,
+              "key": "project_id"
+            }
+          ]
+        }
+      ],
+      "relativeUriPathSegments": [
+        "projects"
+      ],
+      "absoluteUri": "https://api.semaphoreci.com/v2/projects",
+      "parentUrl": "",
+      "uniqueId": "projects",
+      "allUriParameters": []
+    },
+    {
+      "relativeUri": "/shared_configs",
+      "displayName": "Shared Configurations",
+      "resources": [
+        {
+          "methods": [
+            {
+              "responses": [
+                {
+                  "code": "200",
+                  "body": [
+                    {
+                      "name": "SharedConfig",
+                      "displayName": "SharedConfig",
+                      "typePropertyKind": "TYPE_EXPRESSION",
+                      "type": "object",
+                      "additionalProperties": true,
+                      "properties": [
+                        {
+                          "displayName": "name",
+                          "type": "string",
+                          "example": "AWS Tokens",
+                          "required": true,
+                          "key": "name"
+                        },
+                        {
+                          "displayName": "description",
+                          "type": "string",
+                          "example": "AWS tokens for deployment",
+                          "required": false,
+                          "key": "description"
+                        },
+                        {
+                          "displayName": "id",
+                          "type": "string",
+                          "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
+                          "name": "id",
+                          "typePropertyKind": "TYPE_EXPRESSION",
+                          "required": true,
+                          "examples": [
+                            {
+                              "value": "86e78b7e-2f9c-45a7-9939-ec2c9f6f64b5",
+                              "strict": true,
+                              "structuredValue": "86e78b7e-2f9c-45a7-9939-ec2c9f6f64b5"
+                            }
+                          ],
+                          "key": "id"
+                        },
+                        {
+                          "type": "string",
+                          "displayName": "url",
+                          "name": "url",
+                          "typePropertyKind": "TYPE_EXPRESSION",
+                          "required": true,
+                          "examples": [
+                            {
+                              "value": "https://api.semaphoreci.com/v2/shared_configs/86e78b7e-2f9c-45a7-9939-ec2c9f6f64b5",
+                              "strict": true,
+                              "structuredValue": "https://api.semaphoreci.com/v2/shared_configs/86e78b7e-2f9c-45a7-9939-ec2c9f6f64b5"
+                            }
+                          ],
+                          "key": "url"
+                        },
+                        {
+                          "format": "rfc3339",
+                          "displayName": "created_at",
+                          "type": "datetime",
+                          "name": "created_at",
+                          "typePropertyKind": "TYPE_EXPRESSION",
+                          "required": true,
+                          "key": "created_at"
+                        },
+                        {
+                          "format": "rfc3339",
+                          "displayName": "updated_at",
+                          "type": "datetime",
+                          "name": "updated_at",
+                          "typePropertyKind": "TYPE_EXPRESSION",
+                          "required": true,
+                          "key": "updated_at"
+                        }
+                      ],
+                      "key": "application/json"
+                    }
+                  ],
+                  "key": "200"
+                },
+                {
+                  "code": "404",
+                  "body": [
+                    {
+                      "name": "Error",
+                      "displayName": "Error",
+                      "typePropertyKind": "TYPE_EXPRESSION",
+                      "type": "object",
+                      "additionalProperties": true,
+                      "properties": [
+                        {
+                          "type": "string",
+                          "displayName": "message",
+                          "name": "message",
+                          "typePropertyKind": "TYPE_EXPRESSION",
+                          "required": true,
+                          "key": "message"
+                        }
+                      ],
+                      "key": "application/json"
+                    }
+                  ],
+                  "key": "404"
+                }
+              ],
+              "protocols": [
+                "HTTPS"
+              ],
+              "is": [
+                {
+                  "withResponseItem": {
+                    "item": "SharedConfig"
+                  }
+                },
+                "withNotFoundError"
+              ],
+              "displayName": "Get a shared configuration",
+              "method": "get",
+              "allUriParameters": [
+                {
+                  "name": "id",
+                  "displayName": "id",
+                  "typePropertyKind": "TYPE_EXPRESSION",
+                  "type": "string",
+                  "required": true,
+                  "key": "id"
+                }
+              ]
+            },
+            {
+              "responses": [
+                {
+                  "code": "204",
+                  "key": "204"
+                },
+                {
+                  "code": "404",
+                  "body": [
+                    {
+                      "name": "Error",
+                      "displayName": "Error",
+                      "typePropertyKind": "TYPE_EXPRESSION",
+                      "type": "object",
+                      "additionalProperties": true,
+                      "properties": [
+                        {
+                          "type": "string",
+                          "displayName": "message",
+                          "name": "message",
+                          "typePropertyKind": "TYPE_EXPRESSION",
+                          "required": true,
+                          "key": "message"
+                        }
+                      ],
+                      "key": "application/json"
+                    }
+                  ],
+                  "key": "404"
+                }
+              ],
+              "protocols": [
+                "HTTPS"
+              ],
+              "is": [
+                "withNoBodyResponse",
+                "withNotFoundError"
+              ],
+              "displayName": "Delete a shared configuration",
+              "method": "delete",
+              "allUriParameters": [
+                {
+                  "name": "id",
+                  "displayName": "id",
+                  "typePropertyKind": "TYPE_EXPRESSION",
+                  "type": "string",
+                  "required": true,
+                  "key": "id"
+                }
+              ]
+            },
+            {
+              "responses": [
+                {
+                  "code": "200",
+                  "body": [
+                    {
+                      "name": "SharedConfig",
+                      "displayName": "SharedConfig",
+                      "typePropertyKind": "TYPE_EXPRESSION",
+                      "type": "object",
+                      "additionalProperties": true,
+                      "properties": [
+                        {
+                          "displayName": "name",
+                          "type": "string",
+                          "example": "AWS Tokens",
+                          "required": true,
+                          "key": "name"
+                        },
+                        {
+                          "displayName": "description",
+                          "type": "string",
+                          "example": "AWS tokens for deployment",
+                          "required": false,
+                          "key": "description"
+                        },
+                        {
+                          "displayName": "id",
+                          "type": "string",
+                          "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
+                          "name": "id",
+                          "typePropertyKind": "TYPE_EXPRESSION",
+                          "required": true,
+                          "examples": [
+                            {
+                              "value": "86e78b7e-2f9c-45a7-9939-ec2c9f6f64b5",
+                              "strict": true,
+                              "structuredValue": "86e78b7e-2f9c-45a7-9939-ec2c9f6f64b5"
+                            }
+                          ],
+                          "key": "id"
+                        },
+                        {
+                          "type": "string",
+                          "displayName": "url",
+                          "name": "url",
+                          "typePropertyKind": "TYPE_EXPRESSION",
+                          "required": true,
+                          "examples": [
+                            {
+                              "value": "https://api.semaphoreci.com/v2/shared_configs/86e78b7e-2f9c-45a7-9939-ec2c9f6f64b5",
+                              "strict": true,
+                              "structuredValue": "https://api.semaphoreci.com/v2/shared_configs/86e78b7e-2f9c-45a7-9939-ec2c9f6f64b5"
+                            }
+                          ],
+                          "key": "url"
+                        },
+                        {
+                          "format": "rfc3339",
+                          "displayName": "created_at",
+                          "type": "datetime",
+                          "name": "created_at",
+                          "typePropertyKind": "TYPE_EXPRESSION",
+                          "required": true,
+                          "key": "created_at"
+                        },
+                        {
+                          "format": "rfc3339",
+                          "displayName": "updated_at",
+                          "type": "datetime",
+                          "name": "updated_at",
+                          "typePropertyKind": "TYPE_EXPRESSION",
+                          "required": true,
+                          "key": "updated_at"
+                        }
+                      ],
+                      "key": "application/json"
+                    }
+                  ],
+                  "key": "200"
+                },
+                {
+                  "code": "404",
+                  "body": [
+                    {
+                      "name": "Error",
+                      "displayName": "Error",
+                      "typePropertyKind": "TYPE_EXPRESSION",
+                      "type": "object",
+                      "additionalProperties": true,
+                      "properties": [
+                        {
+                          "type": "string",
+                          "displayName": "message",
+                          "name": "message",
+                          "typePropertyKind": "TYPE_EXPRESSION",
+                          "required": true,
+                          "key": "message"
+                        }
+                      ],
+                      "key": "application/json"
+                    }
+                  ],
+                  "key": "404"
+                }
+              ],
+              "body": [
+                {
+                  "name": "SharedConfigPatch",
+                  "displayName": "SharedConfigPatch",
+                  "typePropertyKind": "TYPE_EXPRESSION",
+                  "type": "object",
+                  "additionalProperties": true,
+                  "properties": [
+                    {
+                      "type": "string",
+                      "displayName": "name",
+                      "name": "name",
+                      "typePropertyKind": "TYPE_EXPRESSION",
+                      "required": false,
+                      "examples": [
+                        {
+                          "value": "AWS Tokens",
+                          "strict": true,
+                          "structuredValue": "AWS Tokens"
+                        }
+                      ],
+                      "key": "name"
+                    },
+                    {
+                      "type": "string",
+                      "displayName": "description",
+                      "name": "description",
+                      "typePropertyKind": "TYPE_EXPRESSION",
+                      "required": false,
+                      "examples": [
+                        {
+                          "value": "AWS tokens for deployment",
+                          "strict": true,
+                          "structuredValue": "AWS tokens for deployment"
+                        }
+                      ],
+                      "key": "description"
+                    }
+                  ],
+                  "key": "application/json"
+                }
+              ],
+              "protocols": [
+                "HTTPS"
+              ],
+              "is": [
+                {
+                  "withRequestItem": {
+                    "item": "SharedConfigPatch"
+                  }
+                },
+                {
+                  "withResponseItem": {
+                    "item": "SharedConfig"
+                  }
+                },
+                "withNotFoundError"
+              ],
+              "displayName": "Update a shared configuration",
+              "method": "patch",
+              "allUriParameters": [
+                {
+                  "name": "id",
+                  "displayName": "id",
+                  "typePropertyKind": "TYPE_EXPRESSION",
+                  "type": "string",
+                  "required": true,
+                  "key": "id"
+                }
+              ]
+            }
+          ],
+          "uriParameters": [
+            {
+              "name": "id",
+              "displayName": "id",
+              "typePropertyKind": "TYPE_EXPRESSION",
+              "type": "string",
+              "required": true,
+              "key": "id"
+            }
+          ],
+          "relativeUri": "/{id}",
+          "displayName": "/{id}",
+          "relativeUriPathSegments": [
+            "{id}"
+          ],
+          "absoluteUri": "https://api.semaphoreci.com/v2/shared_configs/{id}",
+          "parentUrl": "/shared_configs",
+          "uniqueId": "shared_configs__id_",
+          "allUriParameters": [
+            {
+              "name": "id",
+              "displayName": "id",
+              "typePropertyKind": "TYPE_EXPRESSION",
+              "type": "string",
+              "required": true,
+              "key": "id"
+            }
+          ]
+        },
+        {
+          "uriParameters": [
+            {
+              "name": "shared_config_id",
+              "displayName": "shared_config_id",
+              "typePropertyKind": "TYPE_EXPRESSION",
+              "type": "string",
+              "required": true,
+              "key": "shared_config_id"
+            }
+          ],
+          "relativeUri": "/{shared_config_id}",
+          "displayName": "/{shared_config_id}",
+          "resources": [
+            {
+              "methods": [
+                {
+                  "responses": [
+                    {
+                      "code": "200",
+                      "body": [
+                        {
+                          "name": "application/json",
+                          "displayName": "application/json",
+                          "typePropertyKind": "TYPE_EXPRESSION",
+                          "type": "array",
+                          "items": {
+                            "additionalProperties": true,
+                            "displayName": "EnvVar",
+                            "type": "object",
+                            "name": "EnvVar",
+                            "typePropertyKind": "TYPE_EXPRESSION",
+                            "properties": [
+                              {
+                                "displayName": "name",
+                                "type": "string",
+                                "example": "API_TOKEN",
+                                "required": true,
+                                "key": "name"
+                              },
+                              {
+                                "displayName": "content",
+                                "type": "string",
+                                "example": "8CgLAxXn",
+                                "required": true,
+                                "key": "content"
+                              },
+                              {
+                                "displayName": "encrypted",
+                                "type": "boolean",
+                                "example": true,
+                                "required": true,
+                                "key": "encrypted"
+                              },
+                              {
+                                "displayName": "id",
+                                "type": "string",
+                                "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
+                                "name": "id",
+                                "typePropertyKind": "TYPE_EXPRESSION",
+                                "required": true,
+                                "examples": [
+                                  {
+                                    "value": "86e78b7e-2f9c-45a7-9939-ec2c9f6f64b5",
+                                    "strict": true,
+                                    "structuredValue": "86e78b7e-2f9c-45a7-9939-ec2c9f6f64b5"
+                                  }
+                                ],
+                                "key": "id"
+                              },
+                              {
+                                "type": "string",
+                                "displayName": "url",
+                                "name": "url",
+                                "typePropertyKind": "TYPE_EXPRESSION",
+                                "required": true,
+                                "examples": [
+                                  {
+                                    "value": "https://api.semaphoreci.com/v2/env_vars/86e78b7e-2f9c-45a7-9939-ec2c9f6f64b5",
+                                    "strict": true,
+                                    "structuredValue": "https://api.semaphoreci.com/v2/env_vars/86e78b7e-2f9c-45a7-9939-ec2c9f6f64b5"
+                                  }
+                                ],
+                                "key": "url"
+                              },
+                              {
+                                "type": "boolean",
+                                "displayName": "shared",
+                                "name": "shared",
+                                "typePropertyKind": "TYPE_EXPRESSION",
+                                "required": true,
+                                "examples": [
+                                  {
+                                    "value": "true",
+                                    "strict": true,
+                                    "structuredValue": true
+                                  }
+                                ],
+                                "key": "shared"
+                              },
+                              {
+                                "format": "rfc3339",
+                                "displayName": "created_at",
+                                "type": "datetime",
+                                "name": "created_at",
+                                "typePropertyKind": "TYPE_EXPRESSION",
+                                "required": true,
+                                "key": "created_at"
+                              },
+                              {
+                                "format": "rfc3339",
+                                "displayName": "updated_at",
+                                "type": "datetime",
+                                "name": "updated_at",
+                                "typePropertyKind": "TYPE_EXPRESSION",
+                                "required": true,
+                                "key": "updated_at"
+                              }
+                            ]
+                          },
+                          "key": "application/json"
+                        }
+                      ],
+                      "key": "200"
+                    },
+                    {
+                      "code": "404",
+                      "body": [
+                        {
+                          "name": "Error",
+                          "displayName": "Error",
+                          "typePropertyKind": "TYPE_EXPRESSION",
+                          "type": "object",
+                          "additionalProperties": true,
+                          "properties": [
+                            {
+                              "type": "string",
+                              "displayName": "message",
+                              "name": "message",
+                              "typePropertyKind": "TYPE_EXPRESSION",
+                              "required": true,
+                              "key": "message"
+                            }
+                          ],
+                          "key": "application/json"
+                        }
+                      ],
+                      "key": "404"
+                    }
+                  ],
+                  "protocols": [
+                    "HTTPS"
+                  ],
+                  "is": [
+                    {
+                      "withResponseItems": {
+                        "item": "EnvVar"
+                      }
+                    },
+                    "withNotFoundError"
+                  ],
+                  "displayName": "List environment variables belonging to a shared configuration",
+                  "method": "get",
+                  "allUriParameters": [
+                    {
+                      "name": "shared_config_id",
+                      "displayName": "shared_config_id",
+                      "typePropertyKind": "TYPE_EXPRESSION",
+                      "type": "string",
+                      "required": true,
+                      "key": "shared_config_id"
+                    }
+                  ]
+                },
+                {
+                  "responses": [
+                    {
+                      "code": "200",
+                      "body": [
+                        {
+                          "name": "EnvVar",
+                          "displayName": "EnvVar",
+                          "typePropertyKind": "TYPE_EXPRESSION",
+                          "type": "object",
+                          "additionalProperties": true,
+                          "properties": [
+                            {
+                              "displayName": "name",
+                              "type": "string",
+                              "example": "API_TOKEN",
+                              "required": true,
+                              "key": "name"
+                            },
+                            {
+                              "displayName": "content",
+                              "type": "string",
+                              "example": "8CgLAxXn",
+                              "required": true,
+                              "key": "content"
+                            },
+                            {
+                              "displayName": "encrypted",
+                              "type": "boolean",
+                              "example": true,
+                              "required": true,
+                              "key": "encrypted"
+                            },
+                            {
+                              "displayName": "id",
+                              "type": "string",
+                              "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
+                              "name": "id",
+                              "typePropertyKind": "TYPE_EXPRESSION",
+                              "required": true,
+                              "examples": [
+                                {
+                                  "value": "86e78b7e-2f9c-45a7-9939-ec2c9f6f64b5",
+                                  "strict": true,
+                                  "structuredValue": "86e78b7e-2f9c-45a7-9939-ec2c9f6f64b5"
+                                }
+                              ],
+                              "key": "id"
+                            },
+                            {
+                              "type": "string",
+                              "displayName": "url",
+                              "name": "url",
+                              "typePropertyKind": "TYPE_EXPRESSION",
+                              "required": true,
+                              "examples": [
+                                {
+                                  "value": "https://api.semaphoreci.com/v2/env_vars/86e78b7e-2f9c-45a7-9939-ec2c9f6f64b5",
+                                  "strict": true,
+                                  "structuredValue": "https://api.semaphoreci.com/v2/env_vars/86e78b7e-2f9c-45a7-9939-ec2c9f6f64b5"
+                                }
+                              ],
+                              "key": "url"
+                            },
+                            {
+                              "type": "boolean",
+                              "displayName": "shared",
+                              "name": "shared",
+                              "typePropertyKind": "TYPE_EXPRESSION",
+                              "required": true,
+                              "examples": [
+                                {
+                                  "value": "true",
+                                  "strict": true,
+                                  "structuredValue": true
+                                }
+                              ],
+                              "key": "shared"
+                            },
+                            {
+                              "format": "rfc3339",
+                              "displayName": "created_at",
+                              "type": "datetime",
+                              "name": "created_at",
+                              "typePropertyKind": "TYPE_EXPRESSION",
+                              "required": true,
+                              "key": "created_at"
+                            },
+                            {
+                              "format": "rfc3339",
+                              "displayName": "updated_at",
+                              "type": "datetime",
+                              "name": "updated_at",
+                              "typePropertyKind": "TYPE_EXPRESSION",
+                              "required": true,
+                              "key": "updated_at"
+                            }
+                          ],
+                          "key": "application/json"
+                        }
+                      ],
+                      "key": "200"
+                    },
+                    {
+                      "code": "404",
+                      "body": [
+                        {
+                          "name": "Error",
+                          "displayName": "Error",
+                          "typePropertyKind": "TYPE_EXPRESSION",
+                          "type": "object",
+                          "additionalProperties": true,
+                          "properties": [
+                            {
+                              "type": "string",
+                              "displayName": "message",
+                              "name": "message",
+                              "typePropertyKind": "TYPE_EXPRESSION",
+                              "required": true,
+                              "key": "message"
+                            }
+                          ],
+                          "key": "application/json"
+                        }
+                      ],
+                      "key": "404"
+                    }
+                  ],
+                  "body": [
+                    {
+                      "name": "EnvVarPost",
+                      "displayName": "EnvVarPost",
+                      "typePropertyKind": "TYPE_EXPRESSION",
+                      "type": "object",
+                      "additionalProperties": true,
+                      "properties": [
+                        {
+                          "type": "string",
+                          "displayName": "name",
+                          "name": "name",
+                          "typePropertyKind": "TYPE_EXPRESSION",
+                          "required": true,
+                          "examples": [
+                            {
+                              "value": "API_TOKEN",
+                              "strict": true,
+                              "structuredValue": "API_TOKEN"
+                            }
+                          ],
+                          "key": "name"
+                        },
+                        {
+                          "type": "string",
+                          "displayName": "content",
+                          "name": "content",
+                          "typePropertyKind": "TYPE_EXPRESSION",
+                          "required": true,
+                          "examples": [
+                            {
+                              "value": "8CgLAxXn",
+                              "strict": true,
+                              "structuredValue": "8CgLAxXn"
+                            }
+                          ],
+                          "key": "content"
+                        },
+                        {
+                          "type": "boolean",
+                          "displayName": "encrypted",
+                          "name": "encrypted",
+                          "typePropertyKind": "TYPE_EXPRESSION",
+                          "required": true,
+                          "examples": [
+                            {
+                              "value": "true",
+                              "strict": true,
+                              "structuredValue": true
+                            }
+                          ],
+                          "key": "encrypted"
+                        }
+                      ],
+                      "key": "application/json"
+                    }
+                  ],
+                  "protocols": [
+                    "HTTPS"
+                  ],
+                  "is": [
+                    {
+                      "withRequestItem": {
+                        "item": "EnvVarPost"
+                      }
+                    },
+                    {
+                      "withResponseItem": {
+                        "item": "EnvVar"
+                      }
+                    },
+                    "withNotFoundError"
+                  ],
+                  "displayName": "Create environment variable within a shared configuration",
+                  "method": "post",
+                  "allUriParameters": [
+                    {
+                      "name": "shared_config_id",
+                      "displayName": "shared_config_id",
+                      "typePropertyKind": "TYPE_EXPRESSION",
+                      "type": "string",
+                      "required": true,
+                      "key": "shared_config_id"
+                    }
+                  ]
+                }
+              ],
+              "relativeUri": "/env_vars",
+              "displayName": "/env_vars",
+              "relativeUriPathSegments": [
+                "env_vars"
+              ],
+              "absoluteUri": "https://api.semaphoreci.com/v2/shared_configs/{shared_config_id}/env_vars",
+              "parentUrl": "/shared_configs/{shared_config_id}",
+              "uniqueId": "shared_configs__shared_config_id__env_vars",
+              "allUriParameters": [
+                {
+                  "name": "shared_config_id",
+                  "displayName": "shared_config_id",
+                  "typePropertyKind": "TYPE_EXPRESSION",
+                  "type": "string",
+                  "required": true,
+                  "key": "shared_config_id"
+                }
+              ]
+            },
+            {
+              "methods": [
+                {
+                  "responses": [
+                    {
+                      "code": "200",
+                      "body": [
+                        {
+                          "name": "application/json",
+                          "displayName": "application/json",
+                          "typePropertyKind": "TYPE_EXPRESSION",
+                          "type": "array",
+                          "items": {
+                            "additionalProperties": true,
+                            "displayName": "ConfigFile",
+                            "type": "object",
+                            "name": "ConfigFile",
+                            "typePropertyKind": "TYPE_EXPRESSION",
+                            "properties": [
+                              {
+                                "displayName": "path",
+                                "type": "string",
+                                "example": ".credentials",
+                                "required": true,
+                                "key": "path"
+                              },
+                              {
+                                "displayName": "content",
+                                "type": "string",
+                                "example": "password: ec2c9f6f64b5",
+                                "required": true,
+                                "key": "content"
+                              },
+                              {
+                                "displayName": "encrypted",
+                                "type": "boolean",
+                                "example": true,
+                                "required": true,
+                                "key": "encrypted"
+                              },
+                              {
+                                "displayName": "id",
+                                "type": "string",
+                                "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
+                                "name": "id",
+                                "typePropertyKind": "TYPE_EXPRESSION",
+                                "required": true,
+                                "examples": [
+                                  {
+                                    "value": "86e78b7e-2f9c-45a7-9939-ec2c9f6f64b5",
+                                    "strict": true,
+                                    "structuredValue": "86e78b7e-2f9c-45a7-9939-ec2c9f6f64b5"
+                                  }
+                                ],
+                                "key": "id"
+                              },
+                              {
+                                "type": "string",
+                                "displayName": "url",
+                                "name": "url",
+                                "typePropertyKind": "TYPE_EXPRESSION",
+                                "required": true,
+                                "examples": [
+                                  {
+                                    "value": "https://api.semaphoreci.com/v2/config_files/86e78b7e-2f9c-45a7-9939-ec2c9f6f64b5",
+                                    "strict": true,
+                                    "structuredValue": "https://api.semaphoreci.com/v2/config_files/86e78b7e-2f9c-45a7-9939-ec2c9f6f64b5"
+                                  }
+                                ],
+                                "key": "url"
+                              },
+                              {
+                                "type": "boolean",
+                                "displayName": "shared",
+                                "name": "shared",
+                                "typePropertyKind": "TYPE_EXPRESSION",
+                                "required": true,
+                                "examples": [
+                                  {
+                                    "value": "true",
+                                    "strict": true,
+                                    "structuredValue": true
+                                  }
+                                ],
+                                "key": "shared"
+                              },
+                              {
+                                "format": "rfc3339",
+                                "displayName": "created_at",
+                                "type": "datetime",
+                                "name": "created_at",
+                                "typePropertyKind": "TYPE_EXPRESSION",
+                                "required": true,
+                                "key": "created_at"
+                              },
+                              {
+                                "format": "rfc3339",
+                                "displayName": "updated_at",
+                                "type": "datetime",
+                                "name": "updated_at",
+                                "typePropertyKind": "TYPE_EXPRESSION",
+                                "required": true,
+                                "key": "updated_at"
+                              }
+                            ]
+                          },
+                          "key": "application/json"
+                        }
+                      ],
+                      "key": "200"
+                    },
+                    {
+                      "code": "404",
+                      "body": [
+                        {
+                          "name": "Error",
+                          "displayName": "Error",
+                          "typePropertyKind": "TYPE_EXPRESSION",
+                          "type": "object",
+                          "additionalProperties": true,
+                          "properties": [
+                            {
+                              "type": "string",
+                              "displayName": "message",
+                              "name": "message",
+                              "typePropertyKind": "TYPE_EXPRESSION",
+                              "required": true,
+                              "key": "message"
+                            }
+                          ],
+                          "key": "application/json"
+                        }
+                      ],
+                      "key": "404"
+                    }
+                  ],
+                  "protocols": [
+                    "HTTPS"
+                  ],
+                  "is": [
+                    {
+                      "withResponseItems": {
+                        "item": "ConfigFile"
+                      }
+                    },
+                    "withNotFoundError"
+                  ],
+                  "displayName": "List config files belonging to a shared configuration",
+                  "method": "get",
+                  "allUriParameters": [
+                    {
+                      "name": "shared_config_id",
+                      "displayName": "shared_config_id",
+                      "typePropertyKind": "TYPE_EXPRESSION",
+                      "type": "string",
+                      "required": true,
+                      "key": "shared_config_id"
+                    }
+                  ]
+                },
+                {
+                  "responses": [
+                    {
+                      "code": "200",
+                      "body": [
+                        {
+                          "name": "ConfigFile",
+                          "displayName": "ConfigFile",
+                          "typePropertyKind": "TYPE_EXPRESSION",
+                          "type": "object",
+                          "additionalProperties": true,
+                          "properties": [
+                            {
+                              "displayName": "path",
+                              "type": "string",
+                              "example": ".credentials",
+                              "required": true,
+                              "key": "path"
+                            },
+                            {
+                              "displayName": "content",
+                              "type": "string",
+                              "example": "password: ec2c9f6f64b5",
+                              "required": true,
+                              "key": "content"
+                            },
+                            {
+                              "displayName": "encrypted",
+                              "type": "boolean",
+                              "example": true,
+                              "required": true,
+                              "key": "encrypted"
+                            },
+                            {
+                              "displayName": "id",
+                              "type": "string",
+                              "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
+                              "name": "id",
+                              "typePropertyKind": "TYPE_EXPRESSION",
+                              "required": true,
+                              "examples": [
+                                {
+                                  "value": "86e78b7e-2f9c-45a7-9939-ec2c9f6f64b5",
+                                  "strict": true,
+                                  "structuredValue": "86e78b7e-2f9c-45a7-9939-ec2c9f6f64b5"
+                                }
+                              ],
+                              "key": "id"
+                            },
+                            {
+                              "type": "string",
+                              "displayName": "url",
+                              "name": "url",
+                              "typePropertyKind": "TYPE_EXPRESSION",
+                              "required": true,
+                              "examples": [
+                                {
+                                  "value": "https://api.semaphoreci.com/v2/config_files/86e78b7e-2f9c-45a7-9939-ec2c9f6f64b5",
+                                  "strict": true,
+                                  "structuredValue": "https://api.semaphoreci.com/v2/config_files/86e78b7e-2f9c-45a7-9939-ec2c9f6f64b5"
+                                }
+                              ],
+                              "key": "url"
+                            },
+                            {
+                              "type": "boolean",
+                              "displayName": "shared",
+                              "name": "shared",
+                              "typePropertyKind": "TYPE_EXPRESSION",
+                              "required": true,
+                              "examples": [
+                                {
+                                  "value": "true",
+                                  "strict": true,
+                                  "structuredValue": true
+                                }
+                              ],
+                              "key": "shared"
+                            },
+                            {
+                              "format": "rfc3339",
+                              "displayName": "created_at",
+                              "type": "datetime",
+                              "name": "created_at",
+                              "typePropertyKind": "TYPE_EXPRESSION",
+                              "required": true,
+                              "key": "created_at"
+                            },
+                            {
+                              "format": "rfc3339",
+                              "displayName": "updated_at",
+                              "type": "datetime",
+                              "name": "updated_at",
+                              "typePropertyKind": "TYPE_EXPRESSION",
+                              "required": true,
+                              "key": "updated_at"
+                            }
+                          ],
+                          "key": "application/json"
+                        }
+                      ],
+                      "key": "200"
+                    },
+                    {
+                      "code": "404",
+                      "body": [
+                        {
+                          "name": "Error",
+                          "displayName": "Error",
+                          "typePropertyKind": "TYPE_EXPRESSION",
+                          "type": "object",
+                          "additionalProperties": true,
+                          "properties": [
+                            {
+                              "type": "string",
+                              "displayName": "message",
+                              "name": "message",
+                              "typePropertyKind": "TYPE_EXPRESSION",
+                              "required": true,
+                              "key": "message"
+                            }
+                          ],
+                          "key": "application/json"
+                        }
+                      ],
+                      "key": "404"
+                    }
+                  ],
+                  "body": [
+                    {
+                      "name": "ConfigFilePost",
+                      "displayName": "ConfigFilePost",
+                      "typePropertyKind": "TYPE_EXPRESSION",
+                      "type": "object",
+                      "additionalProperties": true,
+                      "properties": [
+                        {
+                          "type": "string",
+                          "displayName": "path",
+                          "name": "path",
+                          "typePropertyKind": "TYPE_EXPRESSION",
+                          "required": true,
+                          "examples": [
+                            {
+                              "value": ".credentials",
+                              "strict": true,
+                              "structuredValue": ".credentials"
+                            }
+                          ],
+                          "key": "path"
+                        },
+                        {
+                          "type": "string",
+                          "displayName": "content",
+                          "name": "content",
+                          "typePropertyKind": "TYPE_EXPRESSION",
+                          "required": true,
+                          "examples": [
+                            {
+                              "value": "password: ec2c9f6f64b5",
+                              "strict": true,
+                              "structuredValue": "password: ec2c9f6f64b5"
+                            }
+                          ],
+                          "key": "content"
+                        },
+                        {
+                          "type": "boolean",
+                          "displayName": "encrypted",
+                          "name": "encrypted",
+                          "typePropertyKind": "TYPE_EXPRESSION",
+                          "required": true,
+                          "examples": [
+                            {
+                              "value": "true",
+                              "strict": true,
+                              "structuredValue": true
+                            }
+                          ],
+                          "key": "encrypted"
+                        }
+                      ],
+                      "key": "application/json"
+                    }
+                  ],
+                  "protocols": [
+                    "HTTPS"
+                  ],
+                  "is": [
+                    {
+                      "withRequestItem": {
+                        "item": "ConfigFilePost"
+                      }
+                    },
+                    {
+                      "withResponseItem": {
+                        "item": "ConfigFile"
+                      }
+                    },
+                    "withNotFoundError"
+                  ],
+                  "displayName": "Create a config file within a shared configuration",
+                  "method": "post",
+                  "allUriParameters": [
+                    {
+                      "name": "shared_config_id",
+                      "displayName": "shared_config_id",
+                      "typePropertyKind": "TYPE_EXPRESSION",
+                      "type": "string",
+                      "required": true,
+                      "key": "shared_config_id"
+                    }
+                  ]
+                }
+              ],
+              "relativeUri": "/config_files",
+              "displayName": "/config_files",
+              "relativeUriPathSegments": [
+                "config_files"
+              ],
+              "absoluteUri": "https://api.semaphoreci.com/v2/shared_configs/{shared_config_id}/config_files",
+              "parentUrl": "/shared_configs/{shared_config_id}",
+              "uniqueId": "shared_configs__shared_config_id__config_files",
+              "allUriParameters": [
+                {
+                  "name": "shared_config_id",
+                  "displayName": "shared_config_id",
+                  "typePropertyKind": "TYPE_EXPRESSION",
+                  "type": "string",
+                  "required": true,
+                  "key": "shared_config_id"
+                }
+              ]
+            }
+          ],
+          "relativeUriPathSegments": [
+            "{shared_config_id}"
+          ],
+          "absoluteUri": "https://api.semaphoreci.com/v2/shared_configs/{shared_config_id}",
+          "parentUrl": "/shared_configs",
+          "uniqueId": "shared_configs__shared_config_id_",
+          "allUriParameters": [
+            {
+              "name": "shared_config_id",
+              "displayName": "shared_config_id",
+              "typePropertyKind": "TYPE_EXPRESSION",
+              "type": "string",
+              "required": true,
+              "key": "shared_config_id"
+            }
+          ]
+        }
+      ],
+      "relativeUriPathSegments": [
+        "shared_configs"
+      ],
+      "absoluteUri": "https://api.semaphoreci.com/v2/shared_configs",
+      "parentUrl": "",
+      "uniqueId": "shared_configs",
+      "allUriParameters": []
+    },
+    {
+      "relativeUri": "/env_vars",
+      "displayName": "Environment Variables",
+      "resources": [
+        {
+          "methods": [
+            {
+              "responses": [
+                {
+                  "code": "200",
+                  "body": [
+                    {
+                      "name": "EnvVar",
+                      "displayName": "EnvVar",
+                      "typePropertyKind": "TYPE_EXPRESSION",
+                      "type": "object",
+                      "additionalProperties": true,
+                      "properties": [
+                        {
+                          "displayName": "name",
+                          "type": "string",
+                          "example": "API_TOKEN",
+                          "required": true,
+                          "key": "name"
+                        },
+                        {
+                          "displayName": "content",
+                          "type": "string",
+                          "example": "8CgLAxXn",
+                          "required": true,
+                          "key": "content"
+                        },
+                        {
+                          "displayName": "encrypted",
+                          "type": "boolean",
+                          "example": true,
+                          "required": true,
+                          "key": "encrypted"
+                        },
+                        {
+                          "displayName": "id",
+                          "type": "string",
+                          "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
+                          "name": "id",
+                          "typePropertyKind": "TYPE_EXPRESSION",
+                          "required": true,
+                          "examples": [
+                            {
+                              "value": "86e78b7e-2f9c-45a7-9939-ec2c9f6f64b5",
+                              "strict": true,
+                              "structuredValue": "86e78b7e-2f9c-45a7-9939-ec2c9f6f64b5"
+                            }
+                          ],
+                          "key": "id"
+                        },
+                        {
+                          "type": "string",
+                          "displayName": "url",
+                          "name": "url",
+                          "typePropertyKind": "TYPE_EXPRESSION",
+                          "required": true,
+                          "examples": [
+                            {
+                              "value": "https://api.semaphoreci.com/v2/env_vars/86e78b7e-2f9c-45a7-9939-ec2c9f6f64b5",
+                              "strict": true,
+                              "structuredValue": "https://api.semaphoreci.com/v2/env_vars/86e78b7e-2f9c-45a7-9939-ec2c9f6f64b5"
+                            }
+                          ],
+                          "key": "url"
+                        },
+                        {
+                          "type": "boolean",
+                          "displayName": "shared",
+                          "name": "shared",
+                          "typePropertyKind": "TYPE_EXPRESSION",
+                          "required": true,
+                          "examples": [
+                            {
+                              "value": "true",
+                              "strict": true,
+                              "structuredValue": true
+                            }
+                          ],
+                          "key": "shared"
+                        },
+                        {
+                          "format": "rfc3339",
+                          "displayName": "created_at",
+                          "type": "datetime",
+                          "name": "created_at",
+                          "typePropertyKind": "TYPE_EXPRESSION",
+                          "required": true,
+                          "key": "created_at"
+                        },
+                        {
+                          "format": "rfc3339",
+                          "displayName": "updated_at",
+                          "type": "datetime",
+                          "name": "updated_at",
+                          "typePropertyKind": "TYPE_EXPRESSION",
+                          "required": true,
+                          "key": "updated_at"
+                        }
+                      ],
+                      "key": "application/json"
+                    }
+                  ],
+                  "key": "200"
+                },
+                {
+                  "code": "404",
+                  "body": [
+                    {
+                      "name": "Error",
+                      "displayName": "Error",
+                      "typePropertyKind": "TYPE_EXPRESSION",
+                      "type": "object",
+                      "additionalProperties": true,
+                      "properties": [
+                        {
+                          "type": "string",
+                          "displayName": "message",
+                          "name": "message",
+                          "typePropertyKind": "TYPE_EXPRESSION",
+                          "required": true,
+                          "key": "message"
+                        }
+                      ],
+                      "key": "application/json"
+                    }
+                  ],
+                  "key": "404"
+                }
+              ],
+              "protocols": [
+                "HTTPS"
+              ],
+              "is": [
+                {
+                  "withResponseItem": {
+                    "item": "EnvVar"
+                  }
+                },
+                "withNotFoundError"
+              ],
+              "displayName": "Get an environment variable",
+              "method": "get",
+              "allUriParameters": [
+                {
+                  "name": "id",
+                  "displayName": "id",
+                  "typePropertyKind": "TYPE_EXPRESSION",
+                  "type": "string",
+                  "required": true,
+                  "key": "id"
+                }
+              ]
+            },
+            {
+              "responses": [
+                {
+                  "code": "204",
+                  "key": "204"
+                },
+                {
+                  "code": "404",
+                  "body": [
+                    {
+                      "name": "Error",
+                      "displayName": "Error",
+                      "typePropertyKind": "TYPE_EXPRESSION",
+                      "type": "object",
+                      "additionalProperties": true,
+                      "properties": [
+                        {
+                          "type": "string",
+                          "displayName": "message",
+                          "name": "message",
+                          "typePropertyKind": "TYPE_EXPRESSION",
+                          "required": true,
+                          "key": "message"
+                        }
+                      ],
+                      "key": "application/json"
+                    }
+                  ],
+                  "key": "404"
+                }
+              ],
+              "protocols": [
+                "HTTPS"
+              ],
+              "is": [
+                "withNoBodyResponse",
+                "withNotFoundError"
+              ],
+              "displayName": "Delete an environment variable",
+              "method": "delete",
+              "allUriParameters": [
+                {
+                  "name": "id",
+                  "displayName": "id",
+                  "typePropertyKind": "TYPE_EXPRESSION",
+                  "type": "string",
+                  "required": true,
+                  "key": "id"
+                }
+              ]
+            },
+            {
+              "responses": [
+                {
+                  "code": "200",
+                  "body": [
+                    {
+                      "name": "EnvVar",
+                      "displayName": "EnvVar",
+                      "typePropertyKind": "TYPE_EXPRESSION",
+                      "type": "object",
+                      "additionalProperties": true,
+                      "properties": [
+                        {
+                          "displayName": "name",
+                          "type": "string",
+                          "example": "API_TOKEN",
+                          "required": true,
+                          "key": "name"
+                        },
+                        {
+                          "displayName": "content",
+                          "type": "string",
+                          "example": "8CgLAxXn",
+                          "required": true,
+                          "key": "content"
+                        },
+                        {
+                          "displayName": "encrypted",
+                          "type": "boolean",
+                          "example": true,
+                          "required": true,
+                          "key": "encrypted"
+                        },
+                        {
+                          "displayName": "id",
+                          "type": "string",
+                          "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
+                          "name": "id",
+                          "typePropertyKind": "TYPE_EXPRESSION",
+                          "required": true,
+                          "examples": [
+                            {
+                              "value": "86e78b7e-2f9c-45a7-9939-ec2c9f6f64b5",
+                              "strict": true,
+                              "structuredValue": "86e78b7e-2f9c-45a7-9939-ec2c9f6f64b5"
+                            }
+                          ],
+                          "key": "id"
+                        },
+                        {
+                          "type": "string",
+                          "displayName": "url",
+                          "name": "url",
+                          "typePropertyKind": "TYPE_EXPRESSION",
+                          "required": true,
+                          "examples": [
+                            {
+                              "value": "https://api.semaphoreci.com/v2/env_vars/86e78b7e-2f9c-45a7-9939-ec2c9f6f64b5",
+                              "strict": true,
+                              "structuredValue": "https://api.semaphoreci.com/v2/env_vars/86e78b7e-2f9c-45a7-9939-ec2c9f6f64b5"
+                            }
+                          ],
+                          "key": "url"
+                        },
+                        {
+                          "type": "boolean",
+                          "displayName": "shared",
+                          "name": "shared",
+                          "typePropertyKind": "TYPE_EXPRESSION",
+                          "required": true,
+                          "examples": [
+                            {
+                              "value": "true",
+                              "strict": true,
+                              "structuredValue": true
+                            }
+                          ],
+                          "key": "shared"
+                        },
+                        {
+                          "format": "rfc3339",
+                          "displayName": "created_at",
+                          "type": "datetime",
+                          "name": "created_at",
+                          "typePropertyKind": "TYPE_EXPRESSION",
+                          "required": true,
+                          "key": "created_at"
+                        },
+                        {
+                          "format": "rfc3339",
+                          "displayName": "updated_at",
+                          "type": "datetime",
+                          "name": "updated_at",
+                          "typePropertyKind": "TYPE_EXPRESSION",
+                          "required": true,
+                          "key": "updated_at"
+                        }
+                      ],
+                      "key": "application/json"
+                    }
+                  ],
+                  "key": "200"
+                },
+                {
+                  "code": "404",
+                  "body": [
+                    {
+                      "name": "Error",
+                      "displayName": "Error",
+                      "typePropertyKind": "TYPE_EXPRESSION",
+                      "type": "object",
+                      "additionalProperties": true,
+                      "properties": [
+                        {
+                          "type": "string",
+                          "displayName": "message",
+                          "name": "message",
+                          "typePropertyKind": "TYPE_EXPRESSION",
+                          "required": true,
+                          "key": "message"
+                        }
+                      ],
+                      "key": "application/json"
+                    }
+                  ],
+                  "key": "404"
+                }
+              ],
+              "body": [
+                {
+                  "name": "EnvVarPatch",
+                  "displayName": "EnvVarPatch",
+                  "typePropertyKind": "TYPE_EXPRESSION",
+                  "type": "object",
+                  "additionalProperties": true,
+                  "properties": [
+                    {
+                      "type": "string",
+                      "displayName": "name",
+                      "name": "name",
+                      "typePropertyKind": "TYPE_EXPRESSION",
+                      "required": false,
+                      "examples": [
+                        {
+                          "value": "API_TOKEN",
+                          "strict": true,
+                          "structuredValue": "API_TOKEN"
+                        }
+                      ],
+                      "key": "name"
+                    },
+                    {
+                      "type": "string",
+                      "displayName": "content",
+                      "name": "content",
+                      "typePropertyKind": "TYPE_EXPRESSION",
+                      "required": false,
+                      "examples": [
+                        {
+                          "value": "8CgLAxXn",
+                          "strict": true,
+                          "structuredValue": "8CgLAxXn"
+                        }
+                      ],
+                      "key": "content"
+                    }
+                  ],
+                  "key": "application/json"
+                }
+              ],
+              "protocols": [
+                "HTTPS"
+              ],
+              "is": [
+                {
+                  "withRequestItem": {
+                    "item": "EnvVarPatch"
+                  }
+                },
+                {
+                  "withResponseItem": {
+                    "item": "EnvVar"
+                  }
+                },
+                "withNotFoundError"
+              ],
+              "displayName": "Update an environment variable",
+              "method": "patch",
+              "allUriParameters": [
+                {
+                  "name": "id",
+                  "displayName": "id",
+                  "typePropertyKind": "TYPE_EXPRESSION",
+                  "type": "string",
+                  "required": true,
+                  "key": "id"
+                }
+              ]
+            }
+          ],
+          "uriParameters": [
+            {
+              "name": "id",
+              "displayName": "id",
+              "typePropertyKind": "TYPE_EXPRESSION",
+              "type": "string",
+              "required": true,
+              "key": "id"
+            }
+          ],
+          "relativeUri": "/{id}",
+          "displayName": "/{id}",
+          "relativeUriPathSegments": [
+            "{id}"
+          ],
+          "absoluteUri": "https://api.semaphoreci.com/v2/env_vars/{id}",
+          "parentUrl": "/env_vars",
+          "uniqueId": "env_vars__id_",
+          "allUriParameters": [
+            {
+              "name": "id",
+              "displayName": "id",
+              "typePropertyKind": "TYPE_EXPRESSION",
+              "type": "string",
+              "required": true,
+              "key": "id"
+            }
+          ]
+        }
+      ],
+      "relativeUriPathSegments": [
+        "env_vars"
+      ],
+      "absoluteUri": "https://api.semaphoreci.com/v2/env_vars",
+      "parentUrl": "",
+      "uniqueId": "env_vars",
+      "allUriParameters": []
+    },
+    {
+      "relativeUri": "/config_files",
+      "displayName": "Configuration Files",
+      "resources": [
+        {
+          "methods": [
+            {
+              "responses": [
+                {
+                  "code": "200",
+                  "body": [
+                    {
+                      "name": "ConfigFile",
+                      "displayName": "ConfigFile",
+                      "typePropertyKind": "TYPE_EXPRESSION",
+                      "type": "object",
+                      "additionalProperties": true,
+                      "properties": [
+                        {
+                          "displayName": "path",
+                          "type": "string",
+                          "example": ".credentials",
+                          "required": true,
+                          "key": "path"
+                        },
+                        {
+                          "displayName": "content",
+                          "type": "string",
+                          "example": "password: ec2c9f6f64b5",
+                          "required": true,
+                          "key": "content"
+                        },
+                        {
+                          "displayName": "encrypted",
+                          "type": "boolean",
+                          "example": true,
+                          "required": true,
+                          "key": "encrypted"
+                        },
+                        {
+                          "displayName": "id",
+                          "type": "string",
+                          "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
+                          "name": "id",
+                          "typePropertyKind": "TYPE_EXPRESSION",
+                          "required": true,
+                          "examples": [
+                            {
+                              "value": "86e78b7e-2f9c-45a7-9939-ec2c9f6f64b5",
+                              "strict": true,
+                              "structuredValue": "86e78b7e-2f9c-45a7-9939-ec2c9f6f64b5"
+                            }
+                          ],
+                          "key": "id"
+                        },
+                        {
+                          "type": "string",
+                          "displayName": "url",
+                          "name": "url",
+                          "typePropertyKind": "TYPE_EXPRESSION",
+                          "required": true,
+                          "examples": [
+                            {
+                              "value": "https://api.semaphoreci.com/v2/config_files/86e78b7e-2f9c-45a7-9939-ec2c9f6f64b5",
+                              "strict": true,
+                              "structuredValue": "https://api.semaphoreci.com/v2/config_files/86e78b7e-2f9c-45a7-9939-ec2c9f6f64b5"
+                            }
+                          ],
+                          "key": "url"
+                        },
+                        {
+                          "type": "boolean",
+                          "displayName": "shared",
+                          "name": "shared",
+                          "typePropertyKind": "TYPE_EXPRESSION",
+                          "required": true,
+                          "examples": [
+                            {
+                              "value": "true",
+                              "strict": true,
+                              "structuredValue": true
+                            }
+                          ],
+                          "key": "shared"
+                        },
+                        {
+                          "format": "rfc3339",
+                          "displayName": "created_at",
+                          "type": "datetime",
+                          "name": "created_at",
+                          "typePropertyKind": "TYPE_EXPRESSION",
+                          "required": true,
+                          "key": "created_at"
+                        },
+                        {
+                          "format": "rfc3339",
+                          "displayName": "updated_at",
+                          "type": "datetime",
+                          "name": "updated_at",
+                          "typePropertyKind": "TYPE_EXPRESSION",
+                          "required": true,
+                          "key": "updated_at"
+                        }
+                      ],
+                      "key": "application/json"
+                    }
+                  ],
+                  "key": "200"
+                },
+                {
+                  "code": "404",
+                  "body": [
+                    {
+                      "name": "Error",
+                      "displayName": "Error",
+                      "typePropertyKind": "TYPE_EXPRESSION",
+                      "type": "object",
+                      "additionalProperties": true,
+                      "properties": [
+                        {
+                          "type": "string",
+                          "displayName": "message",
+                          "name": "message",
+                          "typePropertyKind": "TYPE_EXPRESSION",
+                          "required": true,
+                          "key": "message"
+                        }
+                      ],
+                      "key": "application/json"
+                    }
+                  ],
+                  "key": "404"
+                }
+              ],
+              "protocols": [
+                "HTTPS"
+              ],
+              "is": [
+                {
+                  "withResponseItem": {
+                    "item": "ConfigFile"
+                  }
+                },
+                "withNotFoundError"
+              ],
+              "displayName": "Get a config file",
+              "method": "get",
+              "allUriParameters": [
+                {
+                  "name": "id",
+                  "displayName": "id",
+                  "typePropertyKind": "TYPE_EXPRESSION",
+                  "type": "string",
+                  "required": true,
+                  "key": "id"
+                }
+              ]
+            },
+            {
+              "responses": [
+                {
+                  "code": "204",
+                  "key": "204"
+                },
+                {
+                  "code": "404",
+                  "body": [
+                    {
+                      "name": "Error",
+                      "displayName": "Error",
+                      "typePropertyKind": "TYPE_EXPRESSION",
+                      "type": "object",
+                      "additionalProperties": true,
+                      "properties": [
+                        {
+                          "type": "string",
+                          "displayName": "message",
+                          "name": "message",
+                          "typePropertyKind": "TYPE_EXPRESSION",
+                          "required": true,
+                          "key": "message"
+                        }
+                      ],
+                      "key": "application/json"
+                    }
+                  ],
+                  "key": "404"
+                }
+              ],
+              "protocols": [
+                "HTTPS"
+              ],
+              "is": [
+                "withNoBodyResponse",
+                "withNotFoundError"
+              ],
+              "displayName": "Delete a config file",
+              "method": "delete",
+              "allUriParameters": [
+                {
+                  "name": "id",
+                  "displayName": "id",
+                  "typePropertyKind": "TYPE_EXPRESSION",
+                  "type": "string",
+                  "required": true,
+                  "key": "id"
+                }
+              ]
+            },
+            {
+              "responses": [
+                {
+                  "code": "200",
+                  "body": [
+                    {
+                      "name": "ConfigFile",
+                      "displayName": "ConfigFile",
+                      "typePropertyKind": "TYPE_EXPRESSION",
+                      "type": "object",
+                      "additionalProperties": true,
+                      "properties": [
+                        {
+                          "displayName": "path",
+                          "type": "string",
+                          "example": ".credentials",
+                          "required": true,
+                          "key": "path"
+                        },
+                        {
+                          "displayName": "content",
+                          "type": "string",
+                          "example": "password: ec2c9f6f64b5",
+                          "required": true,
+                          "key": "content"
+                        },
+                        {
+                          "displayName": "encrypted",
+                          "type": "boolean",
+                          "example": true,
+                          "required": true,
+                          "key": "encrypted"
+                        },
+                        {
+                          "displayName": "id",
+                          "type": "string",
+                          "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
+                          "name": "id",
+                          "typePropertyKind": "TYPE_EXPRESSION",
+                          "required": true,
+                          "examples": [
+                            {
+                              "value": "86e78b7e-2f9c-45a7-9939-ec2c9f6f64b5",
+                              "strict": true,
+                              "structuredValue": "86e78b7e-2f9c-45a7-9939-ec2c9f6f64b5"
+                            }
+                          ],
+                          "key": "id"
+                        },
+                        {
+                          "type": "string",
+                          "displayName": "url",
+                          "name": "url",
+                          "typePropertyKind": "TYPE_EXPRESSION",
+                          "required": true,
+                          "examples": [
+                            {
+                              "value": "https://api.semaphoreci.com/v2/config_files/86e78b7e-2f9c-45a7-9939-ec2c9f6f64b5",
+                              "strict": true,
+                              "structuredValue": "https://api.semaphoreci.com/v2/config_files/86e78b7e-2f9c-45a7-9939-ec2c9f6f64b5"
+                            }
+                          ],
+                          "key": "url"
+                        },
+                        {
+                          "type": "boolean",
+                          "displayName": "shared",
+                          "name": "shared",
+                          "typePropertyKind": "TYPE_EXPRESSION",
+                          "required": true,
+                          "examples": [
+                            {
+                              "value": "true",
+                              "strict": true,
+                              "structuredValue": true
+                            }
+                          ],
+                          "key": "shared"
+                        },
+                        {
+                          "format": "rfc3339",
+                          "displayName": "created_at",
+                          "type": "datetime",
+                          "name": "created_at",
+                          "typePropertyKind": "TYPE_EXPRESSION",
+                          "required": true,
+                          "key": "created_at"
+                        },
+                        {
+                          "format": "rfc3339",
+                          "displayName": "updated_at",
+                          "type": "datetime",
+                          "name": "updated_at",
+                          "typePropertyKind": "TYPE_EXPRESSION",
+                          "required": true,
+                          "key": "updated_at"
+                        }
+                      ],
+                      "key": "application/json"
+                    }
+                  ],
+                  "key": "200"
+                },
+                {
+                  "code": "404",
+                  "body": [
+                    {
+                      "name": "Error",
+                      "displayName": "Error",
+                      "typePropertyKind": "TYPE_EXPRESSION",
+                      "type": "object",
+                      "additionalProperties": true,
+                      "properties": [
+                        {
+                          "type": "string",
+                          "displayName": "message",
+                          "name": "message",
+                          "typePropertyKind": "TYPE_EXPRESSION",
+                          "required": true,
+                          "key": "message"
+                        }
+                      ],
+                      "key": "application/json"
+                    }
+                  ],
+                  "key": "404"
+                }
+              ],
+              "body": [
+                {
+                  "name": "ConfigFilePatch",
+                  "displayName": "ConfigFilePatch",
+                  "typePropertyKind": "TYPE_EXPRESSION",
+                  "type": "object",
+                  "additionalProperties": true,
+                  "properties": [
+                    {
+                      "type": "string",
+                      "displayName": "path",
+                      "name": "path",
+                      "typePropertyKind": "TYPE_EXPRESSION",
+                      "required": false,
+                      "examples": [
+                        {
+                          "value": ".credentials",
+                          "strict": true,
+                          "structuredValue": ".credentials"
+                        }
+                      ],
+                      "key": "path"
+                    },
+                    {
+                      "type": "string",
+                      "displayName": "content",
+                      "name": "content",
+                      "typePropertyKind": "TYPE_EXPRESSION",
+                      "required": false,
+                      "examples": [
+                        {
+                          "value": "password: ec2c9f6f64b5",
+                          "strict": true,
+                          "structuredValue": "password: ec2c9f6f64b5"
+                        }
+                      ],
+                      "key": "content"
+                    }
+                  ],
+                  "key": "application/json"
+                }
+              ],
+              "protocols": [
+                "HTTPS"
+              ],
+              "is": [
+                {
+                  "withRequestItem": {
+                    "item": "ConfigFilePatch"
+                  }
+                },
+                {
+                  "withResponseItem": {
+                    "item": "ConfigFile"
+                  }
+                },
+                "withNotFoundError"
+              ],
+              "displayName": "Update a config file",
+              "method": "patch",
+              "allUriParameters": [
+                {
+                  "name": "id",
+                  "displayName": "id",
+                  "typePropertyKind": "TYPE_EXPRESSION",
+                  "type": "string",
+                  "required": true,
+                  "key": "id"
+                }
+              ]
+            }
+          ],
+          "uriParameters": [
+            {
+              "name": "id",
+              "displayName": "id",
+              "typePropertyKind": "TYPE_EXPRESSION",
+              "type": "string",
+              "required": true,
+              "key": "id"
+            }
+          ],
+          "relativeUri": "/{id}",
+          "displayName": "/{id}",
+          "relativeUriPathSegments": [
+            "{id}"
+          ],
+          "absoluteUri": "https://api.semaphoreci.com/v2/config_files/{id}",
+          "parentUrl": "/config_files",
+          "uniqueId": "config_files__id_",
+          "allUriParameters": [
+            {
+              "name": "id",
+              "displayName": "id",
+              "typePropertyKind": "TYPE_EXPRESSION",
+              "type": "string",
+              "required": true,
+              "key": "id"
+            }
+          ]
+        }
+      ],
+      "relativeUriPathSegments": [
+        "config_files"
+      ],
+      "absoluteUri": "https://api.semaphoreci.com/v2/config_files",
+      "parentUrl": "",
+      "uniqueId": "config_files",
+      "allUriParameters": []
+    }
+  ],
+  "types": {
+    "UUID": {
+      "type": "string",
+      "displayName": "UUID",
+      "name": "UUID",
+      "typePropertyKind": "TYPE_EXPRESSION",
+      "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+    },
+    "time": {
+      "type": "datetime",
+      "format": "rfc3339",
+      "displayName": "time",
+      "name": "time",
+      "typePropertyKind": "TYPE_EXPRESSION"
+    },
+    "Error": {
+      "additionalProperties": true,
+      "type": "object",
+      "displayName": "Error",
+      "name": "Error",
+      "typePropertyKind": "TYPE_EXPRESSION",
+      "properties": {
+        "message": {
+          "type": "string",
+          "displayName": "message",
+          "name": "message",
+          "typePropertyKind": "TYPE_EXPRESSION",
+          "required": true,
+          "key": "message"
+        }
+      }
+    },
+    "Org": {
+      "additionalProperties": true,
+      "type": "object",
+      "displayName": "Org",
+      "name": "Org",
+      "typePropertyKind": "TYPE_EXPRESSION",
+      "properties": [
+        {
+          "displayName": "id",
+          "type": "string",
+          "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
+          "name": "id",
+          "typePropertyKind": "TYPE_EXPRESSION",
+          "required": true,
+          "examples": [
+            {
+              "value": "86e78b7e-2f9c-45a7-9939-ec2c9f6f64b5",
+              "strict": true,
+              "structuredValue": "86e78b7e-2f9c-45a7-9939-ec2c9f6f64b5"
+            }
+          ],
+          "key": "id"
+        },
+        {
+          "type": "string",
+          "displayName": "name",
+          "name": "name",
+          "typePropertyKind": "TYPE_EXPRESSION",
+          "required": true,
+          "examples": [
+            {
+              "value": "Rendered Text",
+              "strict": true,
+              "structuredValue": "Rendered Text"
+            }
+          ],
+          "key": "name"
+        },
+        {
+          "type": "string",
+          "displayName": "url",
+          "name": "url",
+          "typePropertyKind": "TYPE_EXPRESSION",
+          "required": true,
+          "examples": [
+            {
+              "value": "https://api.semaphoreci.com/v2/teams/86e78b7e-2f9c-45a7-9939-ec2c9f6f64b5",
+              "strict": true,
+              "structuredValue": "https://api.semaphoreci.com/v2/teams/86e78b7e-2f9c-45a7-9939-ec2c9f6f64b5"
+            }
+          ],
+          "key": "url"
+        },
+        {
+          "type": "string",
+          "displayName": "username",
+          "name": "username",
+          "typePropertyKind": "TYPE_EXPRESSION",
+          "required": true,
+          "examples": [
+            {
+              "value": "renderedtext",
+              "strict": true,
+              "structuredValue": "renderedtext"
+            }
+          ],
+          "key": "username"
+        },
+        {
+          "format": "rfc3339",
+          "displayName": "created_at",
+          "type": "datetime",
+          "name": "created_at",
+          "typePropertyKind": "TYPE_EXPRESSION",
+          "required": true,
+          "key": "created_at"
+        },
+        {
+          "format": "rfc3339",
+          "displayName": "updated_at",
+          "type": "datetime",
+          "name": "updated_at",
+          "typePropertyKind": "TYPE_EXPRESSION",
+          "required": true,
+          "key": "updated_at"
+        }
+      ]
+    },
+    "TeamPatch": {
+      "additionalProperties": true,
+      "type": "object",
+      "displayName": "TeamPatch",
+      "name": "TeamPatch",
+      "typePropertyKind": "TYPE_EXPRESSION",
+      "properties": {
+        "name": {
+          "type": "string",
+          "displayName": "name",
+          "name": "name",
+          "typePropertyKind": "TYPE_EXPRESSION",
+          "required": false,
+          "examples": [
+            {
+              "value": "developers",
+              "strict": true,
+              "structuredValue": "developers"
+            }
+          ],
+          "key": "name"
+        },
+        "permission": {
+          "type": "string",
+          "enum": [
+            "read",
+            "write",
+            "admin"
+          ],
+          "displayName": "permission",
+          "name": "permission",
+          "typePropertyKind": "TYPE_EXPRESSION",
+          "required": false,
+          "examples": [
+            {
+              "value": "write",
+              "strict": true,
+              "structuredValue": "write"
+            }
+          ],
+          "key": "permission"
+        },
+        "description": {
+          "type": "string",
+          "displayName": "description",
+          "name": "description",
+          "typePropertyKind": "TYPE_EXPRESSION",
+          "required": false,
+          "examples": [
+            {
+              "value": "Developers team",
+              "strict": true,
+              "structuredValue": "Developers team"
+            }
+          ],
+          "key": "description"
+        }
+      }
+    },
+    "TeamPost": {
+      "additionalProperties": true,
+      "type": "object",
+      "displayName": "TeamPost",
+      "name": "TeamPost",
+      "typePropertyKind": "TYPE_EXPRESSION",
+      "properties": {
+        "name": {
+          "type": "string",
+          "displayName": "name",
+          "name": "name",
+          "typePropertyKind": "TYPE_EXPRESSION",
+          "required": true,
+          "examples": [
+            {
+              "value": "developers",
+              "strict": true,
+              "structuredValue": "developers"
+            }
+          ],
+          "key": "name"
+        },
+        "permission": {
+          "type": "string",
+          "enum": [
+            "read",
+            "write",
+            "admin"
+          ],
+          "displayName": "permission",
+          "name": "permission",
+          "typePropertyKind": "TYPE_EXPRESSION",
+          "required": true,
+          "examples": [
+            {
+              "value": "write",
+              "strict": true,
+              "structuredValue": "write"
+            }
+          ],
+          "key": "permission"
+        },
+        "description": {
+          "type": "string",
+          "displayName": "description",
+          "name": "description",
+          "typePropertyKind": "TYPE_EXPRESSION",
+          "required": false,
+          "examples": [
+            {
+              "value": "Developers team",
+              "strict": true,
+              "structuredValue": "Developers team"
+            }
+          ],
+          "key": "description"
+        }
+      }
+    },
+    "Team": {
+      "additionalProperties": true,
+      "displayName": "Team",
+      "type": "object",
+      "name": "Team",
+      "typePropertyKind": "TYPE_EXPRESSION",
+      "properties": [
+        {
+          "displayName": "name",
+          "type": "string",
+          "example": "developers",
+          "required": true,
+          "key": "name"
+        },
+        {
+          "enum": [
+            "read",
+            "write",
+            "admin"
+          ],
+          "displayName": "permission",
+          "type": "string",
+          "example": "write",
+          "required": true,
+          "key": "permission"
+        },
+        {
+          "displayName": "description",
+          "type": "string",
+          "example": "Developers team",
+          "required": false,
+          "key": "description"
+        },
+        {
+          "displayName": "id",
+          "type": "string",
+          "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
+          "name": "id",
+          "typePropertyKind": "TYPE_EXPRESSION",
+          "required": true,
+          "examples": [
+            {
+              "value": "86e78b7e-2f9c-45a7-9939-ec2c9f6f64b5",
+              "strict": true,
+              "structuredValue": "86e78b7e-2f9c-45a7-9939-ec2c9f6f64b5"
+            }
+          ],
+          "key": "id"
+        },
+        {
+          "type": "string",
+          "displayName": "url",
+          "name": "url",
+          "typePropertyKind": "TYPE_EXPRESSION",
+          "required": true,
+          "examples": [
+            {
+              "value": "https://api.semaphoreci.com/v2/teams/86e78b7e-2f9c-45a7-9939-ec2c9f6f64b5",
+              "strict": true,
+              "structuredValue": "https://api.semaphoreci.com/v2/teams/86e78b7e-2f9c-45a7-9939-ec2c9f6f64b5"
+            }
+          ],
+          "key": "url"
+        },
+        {
+          "format": "rfc3339",
+          "displayName": "updated_at",
+          "type": "datetime",
+          "name": "updated_at",
+          "typePropertyKind": "TYPE_EXPRESSION",
+          "required": true,
+          "key": "updated_at"
+        },
+        {
+          "format": "rfc3339",
+          "displayName": "created_at",
+          "type": "datetime",
+          "name": "created_at",
+          "typePropertyKind": "TYPE_EXPRESSION",
+          "required": true,
+          "key": "created_at"
+        }
+      ]
+    },
+    "Project": {
+      "additionalProperties": true,
+      "type": "object",
+      "displayName": "Project",
+      "name": "Project",
+      "typePropertyKind": "TYPE_EXPRESSION",
+      "properties": [
+        {
+          "displayName": "id",
+          "type": "string",
+          "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
+          "name": "id",
+          "typePropertyKind": "TYPE_EXPRESSION",
+          "required": true,
+          "examples": [
+            {
+              "value": "86e78b7e-2f9c-45a7-9939-ec2c9f6f64b5",
+              "strict": true,
+              "structuredValue": "86e78b7e-2f9c-45a7-9939-ec2c9f6f64b5"
+            }
+          ],
+          "key": "id"
+        },
+        {
+          "type": "string",
+          "displayName": "name",
+          "name": "name",
+          "typePropertyKind": "TYPE_EXPRESSION",
+          "required": true,
+          "examples": [
+            {
+              "value": "elixir-lang",
+              "strict": true,
+              "structuredValue": "elixir-lang"
+            }
+          ],
+          "key": "name"
+        },
+        {
+          "format": "rfc3339",
+          "displayName": "updated_at",
+          "type": "datetime",
+          "name": "updated_at",
+          "typePropertyKind": "TYPE_EXPRESSION",
+          "required": true,
+          "key": "updated_at"
+        },
+        {
+          "format": "rfc3339",
+          "displayName": "created_at",
+          "type": "datetime",
+          "name": "created_at",
+          "typePropertyKind": "TYPE_EXPRESSION",
+          "required": true,
+          "key": "created_at"
+        }
+      ]
+    },
+    "SharedConfigPatch": {
+      "additionalProperties": true,
+      "type": "object",
+      "displayName": "SharedConfigPatch",
+      "name": "SharedConfigPatch",
+      "typePropertyKind": "TYPE_EXPRESSION",
+      "properties": {
+        "name": {
+          "type": "string",
+          "displayName": "name",
+          "name": "name",
+          "typePropertyKind": "TYPE_EXPRESSION",
+          "required": false,
+          "examples": [
+            {
+              "value": "AWS Tokens",
+              "strict": true,
+              "structuredValue": "AWS Tokens"
+            }
+          ],
+          "key": "name"
+        },
+        "description": {
+          "type": "string",
+          "displayName": "description",
+          "name": "description",
+          "typePropertyKind": "TYPE_EXPRESSION",
+          "required": false,
+          "examples": [
+            {
+              "value": "AWS tokens for deployment",
+              "strict": true,
+              "structuredValue": "AWS tokens for deployment"
+            }
+          ],
+          "key": "description"
+        }
+      }
+    },
+    "SharedConfigPost": {
+      "additionalProperties": true,
+      "type": "object",
+      "displayName": "SharedConfigPost",
+      "name": "SharedConfigPost",
+      "typePropertyKind": "TYPE_EXPRESSION",
+      "properties": {
+        "name": {
+          "type": "string",
+          "displayName": "name",
+          "name": "name",
+          "typePropertyKind": "TYPE_EXPRESSION",
+          "required": true,
+          "examples": [
+            {
+              "value": "AWS Tokens",
+              "strict": true,
+              "structuredValue": "AWS Tokens"
+            }
+          ],
+          "key": "name"
+        },
+        "description": {
+          "type": "string",
+          "displayName": "description",
+          "name": "description",
+          "typePropertyKind": "TYPE_EXPRESSION",
+          "required": false,
+          "examples": [
+            {
+              "value": "AWS tokens for deployment",
+              "strict": true,
+              "structuredValue": "AWS tokens for deployment"
+            }
+          ],
+          "key": "description"
+        }
+      }
+    },
+    "SharedConfig": {
+      "additionalProperties": true,
+      "displayName": "SharedConfig",
+      "type": "object",
+      "name": "SharedConfig",
+      "typePropertyKind": "TYPE_EXPRESSION",
+      "properties": [
+        {
+          "displayName": "name",
+          "type": "string",
+          "example": "AWS Tokens",
+          "required": true,
+          "key": "name"
+        },
+        {
+          "displayName": "description",
+          "type": "string",
+          "example": "AWS tokens for deployment",
+          "required": false,
+          "key": "description"
+        },
+        {
+          "displayName": "id",
+          "type": "string",
+          "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
+          "name": "id",
+          "typePropertyKind": "TYPE_EXPRESSION",
+          "required": true,
+          "examples": [
+            {
+              "value": "86e78b7e-2f9c-45a7-9939-ec2c9f6f64b5",
+              "strict": true,
+              "structuredValue": "86e78b7e-2f9c-45a7-9939-ec2c9f6f64b5"
+            }
+          ],
+          "key": "id"
+        },
+        {
+          "type": "string",
+          "displayName": "url",
+          "name": "url",
+          "typePropertyKind": "TYPE_EXPRESSION",
+          "required": true,
+          "examples": [
+            {
+              "value": "https://api.semaphoreci.com/v2/shared_configs/86e78b7e-2f9c-45a7-9939-ec2c9f6f64b5",
+              "strict": true,
+              "structuredValue": "https://api.semaphoreci.com/v2/shared_configs/86e78b7e-2f9c-45a7-9939-ec2c9f6f64b5"
+            }
+          ],
+          "key": "url"
+        },
+        {
+          "format": "rfc3339",
+          "displayName": "created_at",
+          "type": "datetime",
+          "name": "created_at",
+          "typePropertyKind": "TYPE_EXPRESSION",
+          "required": true,
+          "key": "created_at"
+        },
+        {
+          "format": "rfc3339",
+          "displayName": "updated_at",
+          "type": "datetime",
+          "name": "updated_at",
+          "typePropertyKind": "TYPE_EXPRESSION",
+          "required": true,
+          "key": "updated_at"
+        }
+      ]
+    },
+    "EnvVarPatch": {
+      "additionalProperties": true,
+      "type": "object",
+      "displayName": "EnvVarPatch",
+      "name": "EnvVarPatch",
+      "typePropertyKind": "TYPE_EXPRESSION",
+      "properties": {
+        "name": {
+          "type": "string",
+          "displayName": "name",
+          "name": "name",
+          "typePropertyKind": "TYPE_EXPRESSION",
+          "required": false,
+          "examples": [
+            {
+              "value": "API_TOKEN",
+              "strict": true,
+              "structuredValue": "API_TOKEN"
+            }
+          ],
+          "key": "name"
+        },
+        "content": {
+          "type": "string",
+          "displayName": "content",
+          "name": "content",
+          "typePropertyKind": "TYPE_EXPRESSION",
+          "required": false,
+          "examples": [
+            {
+              "value": "8CgLAxXn",
+              "strict": true,
+              "structuredValue": "8CgLAxXn"
+            }
+          ],
+          "key": "content"
+        }
+      }
+    },
+    "EnvVarPost": {
+      "additionalProperties": true,
+      "type": "object",
+      "displayName": "EnvVarPost",
+      "name": "EnvVarPost",
+      "typePropertyKind": "TYPE_EXPRESSION",
+      "properties": {
+        "name": {
+          "type": "string",
+          "displayName": "name",
+          "name": "name",
+          "typePropertyKind": "TYPE_EXPRESSION",
+          "required": true,
+          "examples": [
+            {
+              "value": "API_TOKEN",
+              "strict": true,
+              "structuredValue": "API_TOKEN"
+            }
+          ],
+          "key": "name"
+        },
+        "content": {
+          "type": "string",
+          "displayName": "content",
+          "name": "content",
+          "typePropertyKind": "TYPE_EXPRESSION",
+          "required": true,
+          "examples": [
+            {
+              "value": "8CgLAxXn",
+              "strict": true,
+              "structuredValue": "8CgLAxXn"
+            }
+          ],
+          "key": "content"
+        },
+        "encrypted": {
+          "type": "boolean",
+          "displayName": "encrypted",
+          "name": "encrypted",
+          "typePropertyKind": "TYPE_EXPRESSION",
+          "required": true,
+          "examples": [
+            {
+              "value": "true",
+              "strict": true,
+              "structuredValue": true
+            }
+          ],
+          "key": "encrypted"
+        }
+      }
+    },
+    "EnvVar": {
+      "additionalProperties": true,
+      "displayName": "EnvVar",
+      "type": "object",
+      "name": "EnvVar",
+      "typePropertyKind": "TYPE_EXPRESSION",
+      "properties": [
+        {
+          "displayName": "name",
+          "type": "string",
+          "example": "API_TOKEN",
+          "required": true,
+          "key": "name"
+        },
+        {
+          "displayName": "content",
+          "type": "string",
+          "example": "8CgLAxXn",
+          "required": true,
+          "key": "content"
+        },
+        {
+          "displayName": "encrypted",
+          "type": "boolean",
+          "example": true,
+          "required": true,
+          "key": "encrypted"
+        },
+        {
+          "displayName": "id",
+          "type": "string",
+          "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
+          "name": "id",
+          "typePropertyKind": "TYPE_EXPRESSION",
+          "required": true,
+          "examples": [
+            {
+              "value": "86e78b7e-2f9c-45a7-9939-ec2c9f6f64b5",
+              "strict": true,
+              "structuredValue": "86e78b7e-2f9c-45a7-9939-ec2c9f6f64b5"
+            }
+          ],
+          "key": "id"
+        },
+        {
+          "type": "string",
+          "displayName": "url",
+          "name": "url",
+          "typePropertyKind": "TYPE_EXPRESSION",
+          "required": true,
+          "examples": [
+            {
+              "value": "https://api.semaphoreci.com/v2/env_vars/86e78b7e-2f9c-45a7-9939-ec2c9f6f64b5",
+              "strict": true,
+              "structuredValue": "https://api.semaphoreci.com/v2/env_vars/86e78b7e-2f9c-45a7-9939-ec2c9f6f64b5"
+            }
+          ],
+          "key": "url"
+        },
+        {
+          "type": "boolean",
+          "displayName": "shared",
+          "name": "shared",
+          "typePropertyKind": "TYPE_EXPRESSION",
+          "required": true,
+          "examples": [
+            {
+              "value": "true",
+              "strict": true,
+              "structuredValue": true
+            }
+          ],
+          "key": "shared"
+        },
+        {
+          "format": "rfc3339",
+          "displayName": "created_at",
+          "type": "datetime",
+          "name": "created_at",
+          "typePropertyKind": "TYPE_EXPRESSION",
+          "required": true,
+          "key": "created_at"
+        },
+        {
+          "format": "rfc3339",
+          "displayName": "updated_at",
+          "type": "datetime",
+          "name": "updated_at",
+          "typePropertyKind": "TYPE_EXPRESSION",
+          "required": true,
+          "key": "updated_at"
+        }
+      ]
+    },
+    "ConfigFilePatch": {
+      "additionalProperties": true,
+      "type": "object",
+      "displayName": "ConfigFilePatch",
+      "name": "ConfigFilePatch",
+      "typePropertyKind": "TYPE_EXPRESSION",
+      "properties": {
+        "path": {
+          "type": "string",
+          "displayName": "path",
+          "name": "path",
+          "typePropertyKind": "TYPE_EXPRESSION",
+          "required": false,
+          "examples": [
+            {
+              "value": ".credentials",
+              "strict": true,
+              "structuredValue": ".credentials"
+            }
+          ],
+          "key": "path"
+        },
+        "content": {
+          "type": "string",
+          "displayName": "content",
+          "name": "content",
+          "typePropertyKind": "TYPE_EXPRESSION",
+          "required": false,
+          "examples": [
+            {
+              "value": "password: ec2c9f6f64b5",
+              "strict": true,
+              "structuredValue": "password: ec2c9f6f64b5"
+            }
+          ],
+          "key": "content"
+        }
+      }
+    },
+    "ConfigFilePost": {
+      "additionalProperties": true,
+      "type": "object",
+      "displayName": "ConfigFilePost",
+      "name": "ConfigFilePost",
+      "typePropertyKind": "TYPE_EXPRESSION",
+      "properties": {
+        "path": {
+          "type": "string",
+          "displayName": "path",
+          "name": "path",
+          "typePropertyKind": "TYPE_EXPRESSION",
+          "required": true,
+          "examples": [
+            {
+              "value": ".credentials",
+              "strict": true,
+              "structuredValue": ".credentials"
+            }
+          ],
+          "key": "path"
+        },
+        "content": {
+          "type": "string",
+          "displayName": "content",
+          "name": "content",
+          "typePropertyKind": "TYPE_EXPRESSION",
+          "required": true,
+          "examples": [
+            {
+              "value": "password: ec2c9f6f64b5",
+              "strict": true,
+              "structuredValue": "password: ec2c9f6f64b5"
+            }
+          ],
+          "key": "content"
+        },
+        "encrypted": {
+          "type": "boolean",
+          "displayName": "encrypted",
+          "name": "encrypted",
+          "typePropertyKind": "TYPE_EXPRESSION",
+          "required": true,
+          "examples": [
+            {
+              "value": "true",
+              "strict": true,
+              "structuredValue": true
+            }
+          ],
+          "key": "encrypted"
+        }
+      }
+    },
+    "ConfigFile": {
+      "additionalProperties": true,
+      "displayName": "ConfigFile",
+      "type": "object",
+      "name": "ConfigFile",
+      "typePropertyKind": "TYPE_EXPRESSION",
+      "properties": [
+        {
+          "displayName": "path",
+          "type": "string",
+          "example": ".credentials",
+          "required": true,
+          "key": "path"
+        },
+        {
+          "displayName": "content",
+          "type": "string",
+          "example": "password: ec2c9f6f64b5",
+          "required": true,
+          "key": "content"
+        },
+        {
+          "displayName": "encrypted",
+          "type": "boolean",
+          "example": true,
+          "required": true,
+          "key": "encrypted"
+        },
+        {
+          "displayName": "id",
+          "type": "string",
+          "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
+          "name": "id",
+          "typePropertyKind": "TYPE_EXPRESSION",
+          "required": true,
+          "examples": [
+            {
+              "value": "86e78b7e-2f9c-45a7-9939-ec2c9f6f64b5",
+              "strict": true,
+              "structuredValue": "86e78b7e-2f9c-45a7-9939-ec2c9f6f64b5"
+            }
+          ],
+          "key": "id"
+        },
+        {
+          "type": "string",
+          "displayName": "url",
+          "name": "url",
+          "typePropertyKind": "TYPE_EXPRESSION",
+          "required": true,
+          "examples": [
+            {
+              "value": "https://api.semaphoreci.com/v2/config_files/86e78b7e-2f9c-45a7-9939-ec2c9f6f64b5",
+              "strict": true,
+              "structuredValue": "https://api.semaphoreci.com/v2/config_files/86e78b7e-2f9c-45a7-9939-ec2c9f6f64b5"
+            }
+          ],
+          "key": "url"
+        },
+        {
+          "type": "boolean",
+          "displayName": "shared",
+          "name": "shared",
+          "typePropertyKind": "TYPE_EXPRESSION",
+          "required": true,
+          "examples": [
+            {
+              "value": "true",
+              "strict": true,
+              "structuredValue": true
+            }
+          ],
+          "key": "shared"
+        },
+        {
+          "format": "rfc3339",
+          "displayName": "created_at",
+          "type": "datetime",
+          "name": "created_at",
+          "typePropertyKind": "TYPE_EXPRESSION",
+          "required": true,
+          "key": "created_at"
+        },
+        {
+          "format": "rfc3339",
+          "displayName": "updated_at",
+          "type": "datetime",
+          "name": "updated_at",
+          "typePropertyKind": "TYPE_EXPRESSION",
+          "required": true,
+          "key": "updated_at"
+        }
+      ]
+    },
+    "User": {
+      "additionalProperties": true,
+      "type": "object",
+      "displayName": "User",
+      "name": "User",
+      "typePropertyKind": "TYPE_EXPRESSION",
+      "properties": [
+        {
+          "displayName": "uid",
+          "type": "string",
+          "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$",
+          "name": "uid",
+          "typePropertyKind": "TYPE_EXPRESSION",
+          "required": true,
+          "examples": [
+            {
+              "value": "86e78b7e-2f9c-45a7-9939-ec2c9f6f64b5",
+              "strict": true,
+              "structuredValue": "86e78b7e-2f9c-45a7-9939-ec2c9f6f64b5"
+            }
+          ],
+          "key": "uid"
+        },
+        {
+          "type": "string",
+          "displayName": "username",
+          "name": "username",
+          "typePropertyKind": "TYPE_EXPRESSION",
+          "required": true,
+          "examples": [
+            {
+              "value": "johndoe",
+              "strict": true,
+              "structuredValue": "johndoe"
+            }
+          ],
+          "key": "username"
+        },
+        {
+          "type": "string",
+          "displayName": "name",
+          "name": "name",
+          "typePropertyKind": "TYPE_EXPRESSION",
+          "required": true,
+          "examples": [
+            {
+              "value": "John Doe",
+              "strict": true,
+              "structuredValue": "John Doe"
+            }
+          ],
+          "key": "name"
+        },
+        {
+          "format": "rfc3339",
+          "displayName": "created_at",
+          "type": "datetime",
+          "name": "created_at",
+          "typePropertyKind": "TYPE_EXPRESSION",
+          "required": true,
+          "key": "created_at"
+        },
+        {
+          "format": "rfc3339",
+          "displayName": "updated_at",
+          "type": "datetime",
+          "name": "updated_at",
+          "typePropertyKind": "TYPE_EXPRESSION",
+          "required": true,
+          "key": "updated_at"
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Moved this gem from `api-dev-tools` into this repo. The two repos are coupled by design and it is a hassle to jump between them.