### PR TITLE
List projects and teams for shared config

### DIFF
--- a/api.raml
+++ b/api.raml
@@ -483,6 +483,16 @@ traits:
           withResponseItem: {item : SharedConfig}, withNotFoundError]
 
   /{shared_config_id}:
+    /projects:
+      get:
+        displayName: List projects for a shared configuration
+        is: [withResponseItems: {item : Project}, withNotFoundError]
+
+    /teams:
+      get:
+        displayName: List teams for a shared configuration
+        is: [withResponseItems: {item : Team}, withNotFoundError]
+
     /env_vars:
       get:
         displayName: List environment variables belonging to a shared configuration


### PR DESCRIPTION
Yesterday I added a shared configuration to one of our projects on
Semaphore, but I forgot which one. Today I realized that there is
no easy way to find it out via the API.

This PR adds:

```
sem get /shared_configs/<id>/projects
sem get /shared_configs/<id>/teams
```